### PR TITLE
Add GoReleaser setup for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,61 @@
+version: 2
+
+before:
+  hooks:
+    - cmd: npm ci
+      dir: frontend
+    - cmd: npm run build
+      dir: frontend
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - formats:
+      - tar.gz
+    files:
+      - README.md
+      - LICENSE
+
+dockers:
+  - image_templates:
+      - "ghcr.io/tokuhirom/dashyard:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    goarch: amd64
+  - image_templates:
+      - "ghcr.io/tokuhirom/dashyard:{{ .Version }}-arm64"
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/tokuhirom/dashyard:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/tokuhirom/dashyard:{{ .Version }}-amd64"
+      - "ghcr.io/tokuhirom/dashyard:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/tokuhirom/dashyard:latest"
+    image_templates:
+      - "ghcr.io/tokuhirom/dashyard:{{ .Version }}-amd64"
+      - "ghcr.io/tokuhirom/dashyard:{{ .Version }}-arm64"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,7 @@
+FROM alpine:3.20
+RUN apk --no-cache add ca-certificates
+WORKDIR /app
+COPY dashyard /app/dashyard
+EXPOSE 8080
+ENTRYPOINT ["/app/dashyard"]
+CMD ["-config", "/etc/dashyard/config.yaml"]


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` to build cross-platform binaries (linux/darwin, amd64/arm64) and multi-arch Docker images pushed to `ghcr.io/tokuhirom/dashyard`
- Add `.github/workflows/release.yml` triggered on `v*` tag pushes (from tagpr) to run GoReleaser with Node 20, Go, and GHCR authentication
- Add `Dockerfile.goreleaser` as a minimal Alpine-based runtime image for GoReleaser Docker builds

## Test plan
- [ ] Push a `v*` tag (or let tagpr create one) and verify the release workflow runs
- [ ] Check GitHub Releases for archives (4 platform combinations)
- [ ] Check `ghcr.io/tokuhirom/dashyard` for multi-arch Docker images

🤖 Generated with [Claude Code](https://claude.com/claude-code)