### PR TITLE
Fix goreleaser before hooks YAML format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,10 +2,8 @@ version: 2
 
 before:
   hooks:
-    - cmd: npm ci
-      dir: frontend
-    - cmd: npm run build
-      dir: frontend
+    - bash -c "cd frontend && npm ci"
+    - bash -c "cd frontend && npm run build"
 
 builds:
   - env:


### PR DESCRIPTION
## Summary
- Fix `before.hooks` in `.goreleaser.yaml` that caused `yaml: unmarshal errors: cannot unmarshal !!map into string`
- Replace `cmd`/`dir` map syntax with plain string commands using `bash -c "cd frontend && ..."`

## Test plan
- [ ] Merge and let tagpr create the next tag
- [ ] Verify the release workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)