### PR TITLE
Add hot-reload for dashboard files using fsnotify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=

--- a/internal/dashboard/storeholder.go
+++ b/internal/dashboard/storeholder.go
@@ -1,0 +1,26 @@
+package dashboard
+
+import "sync/atomic"
+
+// StoreHolder provides lock-free concurrent access to a Store that can be
+// atomically replaced (e.g. on dashboard file changes).
+type StoreHolder struct {
+	p atomic.Pointer[Store]
+}
+
+// NewStoreHolder creates a StoreHolder initialised with the given Store.
+func NewStoreHolder(s *Store) *StoreHolder {
+	h := &StoreHolder{}
+	h.p.Store(s)
+	return h
+}
+
+// Store returns the current Store. Safe for concurrent use.
+func (h *StoreHolder) Store() *Store {
+	return h.p.Load()
+}
+
+// Replace atomically swaps the current Store with a new one.
+func (h *StoreHolder) Replace(s *Store) {
+	h.p.Store(s)
+}

--- a/internal/dashboard/storeholder_test.go
+++ b/internal/dashboard/storeholder_test.go
@@ -1,0 +1,38 @@
+package dashboard
+
+import (
+	"testing"
+)
+
+func TestStoreHolderSwap(t *testing.T) {
+	store1, err := LoadDir("../../testdata/dashboards")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	holder := NewStoreHolder(store1)
+
+	// Verify initial store is accessible.
+	got := holder.Store()
+	if got != store1 {
+		t.Fatal("expected holder to return store1")
+	}
+	if got.Get("overview") == nil {
+		t.Fatal("expected 'overview' dashboard in store1")
+	}
+
+	// Create a second (empty) store and swap it in.
+	store2, err := LoadDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	holder.Replace(store2)
+
+	got = holder.Store()
+	if got != store2 {
+		t.Fatal("expected holder to return store2 after Replace")
+	}
+	if got.Get("overview") != nil {
+		t.Error("expected nil for 'overview' in empty store2")
+	}
+}

--- a/internal/dashboard/watcher.go
+++ b/internal/dashboard/watcher.go
@@ -1,0 +1,130 @@
+package dashboard
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher watches a dashboard directory for file changes and hot-reloads
+// the Store when dashboards are added, modified, or removed.
+type Watcher struct {
+	dir      string
+	holder   *StoreHolder
+	debounce time.Duration
+}
+
+// NewWatcher creates a Watcher that will reload dashboards from dir into holder.
+func NewWatcher(dir string, holder *StoreHolder) *Watcher {
+	return &Watcher{
+		dir:      dir,
+		holder:   holder,
+		debounce: 500 * time.Millisecond,
+	}
+}
+
+// Watch blocks until ctx is cancelled, reloading dashboards on file changes.
+func (w *Watcher) Watch(ctx context.Context) error {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer fsw.Close()
+
+	// Add the root dir and all subdirectories.
+	if err := w.addDirs(fsw, w.dir); err != nil {
+		return err
+	}
+
+	slog.Info("watching dashboards for changes", "dir", w.dir)
+
+	var timer *time.Timer
+	var timerC <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			if timer != nil {
+				timer.Stop()
+			}
+			return nil
+
+		case event, ok := <-fsw.Events:
+			if !ok {
+				return nil
+			}
+
+			if !w.relevant(event) {
+				continue
+			}
+
+			// If a new directory was created, start watching it.
+			if event.Has(fsnotify.Create) {
+				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+					_ = fsw.Add(event.Name)
+				}
+			}
+
+			// Reset debounce timer.
+			if timer == nil {
+				timer = time.NewTimer(w.debounce)
+				timerC = timer.C
+			} else {
+				timer.Reset(w.debounce)
+			}
+
+		case err, ok := <-fsw.Errors:
+			if !ok {
+				return nil
+			}
+			slog.Error("filesystem watcher error", "error", err)
+
+		case <-timerC:
+			timer = nil
+			timerC = nil
+			w.reload()
+		}
+	}
+}
+
+// relevant returns true if the event is for a YAML file or a directory.
+func (w *Watcher) relevant(event fsnotify.Event) bool {
+	// Always handle directory events (Create for new subdirs).
+	if event.Has(fsnotify.Create) {
+		if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+			return true
+		}
+	}
+
+	ext := strings.ToLower(filepath.Ext(event.Name))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// reload calls LoadDir and swaps the store on success.
+func (w *Watcher) reload() {
+	store, err := LoadDir(w.dir)
+	if err != nil {
+		slog.Error("failed to reload dashboards, keeping old data", "error", err)
+		return
+	}
+	w.holder.Replace(store)
+	slog.Info("reloaded dashboards", "count", len(store.List()))
+}
+
+// addDirs recursively adds dir and all subdirectories to the watcher.
+func (w *Watcher) addDirs(fsw *fsnotify.Watcher, dir string) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return fsw.Add(path)
+		}
+		return nil
+	})
+}

--- a/internal/dashboard/watcher_test.go
+++ b/internal/dashboard/watcher_test.go
@@ -1,0 +1,193 @@
+package dashboard
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const validDashboardYAML = `title: Test Dashboard
+rows:
+  - panels:
+      - title: Test Panel
+        type: markdown
+        content: hello
+`
+
+// waitFor polls condition every 50ms up to timeout, returning true if met.
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+func TestWatcherReloadOnCreate(t *testing.T) {
+	dir := t.TempDir()
+
+	store, err := LoadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	holder := NewStoreHolder(store)
+
+	w := NewWatcher(dir, holder)
+	w.debounce = 100 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := w.Watch(ctx); err != nil {
+			t.Errorf("watcher error: %v", err)
+		}
+	}()
+
+	// Give the watcher time to start.
+	time.Sleep(200 * time.Millisecond)
+
+	// Create a new dashboard file.
+	if err := os.WriteFile(filepath.Join(dir, "new.yaml"), []byte(validDashboardYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(t, 3*time.Second, func() bool {
+		return holder.Store().Get("new") != nil
+	}) {
+		t.Error("expected 'new' dashboard after file creation")
+	}
+}
+
+func TestWatcherReloadOnDelete(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-create a dashboard.
+	if err := os.WriteFile(filepath.Join(dir, "existing.yaml"), []byte(validDashboardYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := LoadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.Get("existing") == nil {
+		t.Fatal("expected 'existing' dashboard")
+	}
+
+	holder := NewStoreHolder(store)
+	w := NewWatcher(dir, holder)
+	w.debounce = 100 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := w.Watch(ctx); err != nil {
+			t.Errorf("watcher error: %v", err)
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Remove the file.
+	if err := os.Remove(filepath.Join(dir, "existing.yaml")); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(t, 3*time.Second, func() bool {
+		return holder.Store().Get("existing") == nil
+	}) {
+		t.Error("expected 'existing' dashboard to disappear after deletion")
+	}
+}
+
+func TestWatcherKeepsOldStoreOnError(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "good.yaml"), []byte(validDashboardYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := LoadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	holder := NewStoreHolder(store)
+	w := NewWatcher(dir, holder)
+	w.debounce = 100 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := w.Watch(ctx); err != nil {
+			t.Errorf("watcher error: %v", err)
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Write an invalid YAML file.
+	if err := os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte("{invalid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for debounce + reload attempt.
+	time.Sleep(500 * time.Millisecond)
+
+	// Old data should still be available.
+	if holder.Store().Get("good") == nil {
+		t.Error("expected 'good' dashboard to survive a failed reload")
+	}
+}
+
+func TestWatcherSubdirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	store, err := LoadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	holder := NewStoreHolder(store)
+
+	w := NewWatcher(dir, holder)
+	w.debounce = 100 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := w.Watch(ctx); err != nil {
+			t.Errorf("watcher error: %v", err)
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Create a subdirectory and add a file to it.
+	subdir := filepath.Join(dir, "infra")
+	if err := os.Mkdir(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Small delay to let watcher pick up the new directory.
+	time.Sleep(200 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(subdir, "sub.yaml"), []byte(validDashboardYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(t, 3*time.Second, func() bool {
+		return holder.Store().Get("infra/sub") != nil
+	}) {
+		t.Error("expected 'infra/sub' dashboard after subdirectory file creation")
+	}
+}

--- a/internal/handler/dashboards_test.go
+++ b/internal/handler/dashboards_test.go
@@ -10,18 +10,18 @@ import (
 	"github.com/tokuhirom/dashyard/internal/dashboard"
 )
 
-func loadTestStore(t *testing.T) *dashboard.Store {
+func loadTestHolder(t *testing.T) *dashboard.StoreHolder {
 	t.Helper()
 	store, err := dashboard.LoadDir("../../testdata/dashboards")
 	if err != nil {
 		t.Fatalf("failed to load test dashboards: %v", err)
 	}
-	return store
+	return dashboard.NewStoreHolder(store)
 }
 
 func TestDashboardsList(t *testing.T) {
-	store := loadTestStore(t)
-	handler := NewDashboardsHandler(store, "Dashyard", "")
+	holder := loadTestHolder(t)
+	handler := NewDashboardsHandler(holder, "Dashyard", "")
 
 	router := gin.New()
 	router.GET("/api/dashboards", handler.List)
@@ -51,8 +51,8 @@ func TestDashboardsList(t *testing.T) {
 }
 
 func TestDashboardsGetDeepNested(t *testing.T) {
-	store := loadTestStore(t)
-	handler := NewDashboardsHandler(store, "Dashyard", "")
+	holder := loadTestHolder(t)
+	handler := NewDashboardsHandler(holder, "Dashyard", "")
 
 	router := gin.New()
 	router.GET("/api/dashboards/*path", handler.Get)
@@ -81,8 +81,8 @@ func TestDashboardsGetDeepNested(t *testing.T) {
 }
 
 func TestDashboardsGet(t *testing.T) {
-	store := loadTestStore(t)
-	handler := NewDashboardsHandler(store, "Dashyard", "")
+	holder := loadTestHolder(t)
+	handler := NewDashboardsHandler(holder, "Dashyard", "")
 
 	router := gin.New()
 	router.GET("/api/dashboards/*path", handler.Get)
@@ -111,8 +111,8 @@ func TestDashboardsGet(t *testing.T) {
 }
 
 func TestDashboardsGetNested(t *testing.T) {
-	store := loadTestStore(t)
-	handler := NewDashboardsHandler(store, "Dashyard", "")
+	holder := loadTestHolder(t)
+	handler := NewDashboardsHandler(holder, "Dashyard", "")
 
 	router := gin.New()
 	router.GET("/api/dashboards/*path", handler.Get)
@@ -137,8 +137,8 @@ func TestDashboardsGetNested(t *testing.T) {
 }
 
 func TestDashboardsGetNotFound(t *testing.T) {
-	store := loadTestStore(t)
-	handler := NewDashboardsHandler(store, "Dashyard", "")
+	holder := loadTestHolder(t)
+	handler := NewDashboardsHandler(holder, "Dashyard", "")
 
 	router := gin.New()
 	router.GET("/api/dashboards/*path", handler.Get)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,7 +14,7 @@ import (
 )
 
 // New creates and configures an http.Server with all routes and middleware.
-func New(cfg *config.Config, store *dashboard.Store, frontendFS fs.FS) *http.Server {
+func New(cfg *config.Config, holder *dashboard.StoreHolder, frontendFS fs.FS) *http.Server {
 	gin.SetMode(gin.ReleaseMode)
 
 	r := gin.New()
@@ -29,7 +29,7 @@ func New(cfg *config.Config, store *dashboard.Store, frontendFS fs.FS) *http.Ser
 
 	// Handlers
 	loginHandler := handler.NewLoginHandler(cfg.Users, sm)
-	dashboardsHandler := handler.NewDashboardsHandler(store, cfg.SiteTitle, cfg.HeaderColor)
+	dashboardsHandler := handler.NewDashboardsHandler(holder, cfg.SiteTitle, cfg.HeaderColor)
 	queryHandler := handler.NewQueryHandler(promClient)
 	staticHandler := handler.NewStaticHandler(frontendFS)
 


### PR DESCRIPTION
## Summary
- Watch the dashboards directory (and subdirs) for `.yaml`/`.yml` file changes using `fsnotify`, with 500ms debounce
- Atomically swap the `Store` via `atomic.Pointer` on successful reload — zero overhead on the read path, no locks
- Failed reloads log an error and keep serving the previous data
- New `StoreHolder` wrapper and `Watcher` types in `internal/dashboard/`
- Handler and server updated to use `StoreHolder` instead of a static `*Store`

## Test plan
- [x] `TestStoreHolderSwap` — verifies atomic init/replace semantics
- [x] `TestWatcherReloadOnCreate` — file creation triggers reload
- [x] `TestWatcherReloadOnDelete` — file deletion triggers reload
- [x] `TestWatcherKeepsOldStoreOnError` — invalid YAML keeps old store
- [x] `TestWatcherSubdirectory` — new subdirectory + file triggers reload
- [x] All existing handler tests updated and passing
- [ ] Manual: start server, edit a dashboard YAML, verify API returns updated data

> **Note:** This PR is based on the `kong-subcommands` branch and should be merged after #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)