### PR TITLE
Add dashboard template variables and repeat rows

### DIFF
--- a/examples/dashboards/network-repeat.yaml
+++ b/examples/dashboards/network-repeat.yaml
@@ -1,0 +1,19 @@
+title: "All Network Interfaces"
+variables:
+  - name: device
+    label: "Network Device"
+    query: "label_values(system_network_io_bytes_total, device)"
+rows:
+  - title: "Traffic - $device"
+    repeat: device
+    panels:
+      - title: "Bytes Received ($device)"
+        type: graph
+        query: 'rate(system_network_io_bytes_total{device="$device", direction="receive"}[5m])'
+        unit: bytes
+        legend: "{direction}"
+      - title: "Bytes Transmitted ($device)"
+        type: graph
+        query: 'rate(system_network_io_bytes_total{device="$device", direction="transmit"}[5m])'
+        unit: bytes
+        legend: "{direction}"

--- a/examples/dashboards/network-variable.yaml
+++ b/examples/dashboards/network-variable.yaml
@@ -1,0 +1,18 @@
+title: "Network by Interface"
+variables:
+  - name: device
+    label: "Network Device"
+    query: "label_values(system_network_io_bytes_total, device)"
+rows:
+  - title: "Traffic for $device"
+    panels:
+      - title: "Bytes Received ($device)"
+        type: graph
+        query: 'rate(system_network_io_bytes_total{device="$device", direction="receive"}[5m])'
+        unit: bytes
+        legend: "{direction}"
+      - title: "Bytes Transmitted ($device)"
+        type: graph
+        query: 'rate(system_network_io_bytes_total{device="$device", direction="transmit"}[5m])'
+        unit: bytes
+        legend: "{direction}"

--- a/frontend/e2e/variables.spec.ts
+++ b/frontend/e2e/variables.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Template Variables", () => {
+  test("variable dropdown renders and selects values on variable dashboard", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Navigate to the network-variable dashboard
+    await page
+      .locator(".sidebar-item", { hasText: "network-variable" })
+      .click();
+
+    // Wait for the variable bar to appear
+    const variableBar = page.locator(".variable-bar");
+    await expect(variableBar).toBeVisible({ timeout: 10000 });
+
+    // Should have a select dropdown
+    const select = variableBar.locator(".variable-select");
+    await expect(select).toBeVisible();
+
+    // Should have a label
+    const label = variableBar.locator(".variable-label");
+    await expect(label).toHaveText("Network Device");
+
+    // Dropdown should have options loaded from dummyprom
+    const options = select.locator("option");
+    const count = await options.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // First option should be auto-selected (eth0)
+    const selectedValue = await select.inputValue();
+    expect(selectedValue).toBe("eth0");
+
+    // Row title should contain the substituted variable value
+    const rowTitle = page.locator(".row-title").first();
+    await expect(rowTitle).toContainText("eth0");
+
+    // Graph panels should be visible
+    const panels = page.locator(".panel");
+    await expect(panels.first()).toBeVisible();
+
+    // Change dropdown to second value
+    await select.selectOption({ index: 1 });
+    const newValue = await select.inputValue();
+    expect(newValue).toBe("eth1");
+
+    // Row title should update with new variable value
+    await expect(rowTitle).toContainText("eth1");
+  });
+
+  test("panel titles reflect variable substitution", async ({ page }) => {
+    await page.goto("/");
+
+    await page
+      .locator(".sidebar-item", { hasText: "network-variable" })
+      .click();
+
+    // Wait for variable bar
+    await expect(page.locator(".variable-bar")).toBeVisible({ timeout: 10000 });
+
+    // Panel titles should contain the substituted variable (first selected value)
+    const panelTitles = page.locator(".panel-title");
+    await expect(panelTitles.first()).toBeVisible();
+
+    const firstTitle = await panelTitles.first().textContent();
+    // The title should contain the selected variable value, not the raw $device
+    expect(firstTitle).not.toContain("$device");
+    expect(firstTitle).toContain("eth0");
+  });
+});
+
+test.describe("Repeat Rows", () => {
+  test("repeat row creates one row per variable value", async ({ page }) => {
+    await page.goto("/");
+
+    // Navigate to the network-repeat dashboard
+    await page
+      .locator(".sidebar-item", { hasText: "network-repeat" })
+      .click();
+
+    // Wait for the variable bar to appear
+    await expect(page.locator(".variable-bar")).toBeVisible({ timeout: 10000 });
+
+    // Should have multiple rows (one per device value from dummyprom: eth0, eth1)
+    const rowTitles = page.locator(".row-title");
+    await expect(rowTitles.first()).toBeVisible();
+
+    const rowCount = await rowTitles.count();
+    expect(rowCount).toBeGreaterThanOrEqual(2);
+
+    // Each row should have a different device in its title
+    const titles: string[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const text = await rowTitles.nth(i).textContent();
+      titles.push(text || "");
+    }
+
+    // Verify rows contain different device names
+    const hasEth0 = titles.some((t) => t.includes("eth0"));
+    const hasEth1 = titles.some((t) => t.includes("eth1"));
+    expect(hasEth0).toBe(true);
+    expect(hasEth1).toBe(true);
+  });
+
+  test("repeat rows each have graph panels", async ({ page }) => {
+    await page.goto("/");
+
+    await page
+      .locator(".sidebar-item", { hasText: "network-repeat" })
+      .click();
+
+    await expect(page.locator(".variable-bar")).toBeVisible({ timeout: 10000 });
+
+    // Wait for panels to render
+    await expect(page.locator(".panel").first()).toBeVisible();
+
+    // Each repeated row should have panels
+    const rows = page.locator(".row");
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThanOrEqual(2);
+
+    // Each row should contain graph panels with canvas elements
+    for (let i = 0; i < rowCount; i++) {
+      const panels = rows.nth(i).locator(".panel");
+      const panelCount = await panels.count();
+      expect(panelCount).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  test("repeat row panel titles do not contain raw variable syntax", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await page
+      .locator(".sidebar-item", { hasText: "network-repeat" })
+      .click();
+
+    await expect(page.locator(".variable-bar")).toBeVisible({ timeout: 10000 });
+    await expect(page.locator(".panel-title").first()).toBeVisible();
+
+    // No panel title should contain raw $device
+    const panelTitles = page.locator(".panel-title");
+    const count = await panelTitles.count();
+    for (let i = 0; i < count; i++) {
+      const text = await panelTitles.nth(i).textContent();
+      expect(text).not.toContain("$device");
+    }
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { Dashboard, DashboardsResponse, PrometheusResponse } from '../types';
+import type { Dashboard, DashboardsResponse, LabelValuesResponse, PrometheusResponse } from '../types';
 
 class ApiError extends Error {
   constructor(public status: number, message: string) {
@@ -48,6 +48,14 @@ export async function queryPrometheus(
     step,
   });
   return request(`/api/query?${params}`);
+}
+
+export async function fetchLabelValues(label: string, match?: string): Promise<LabelValuesResponse> {
+  const params = new URLSearchParams({ label });
+  if (match) {
+    params.set('match', match);
+  }
+  return request(`/api/label-values?${params}`);
 }
 
 export async function fetchDashboardSource(path: string): Promise<string> {

--- a/frontend/src/components/RowView.tsx
+++ b/frontend/src/components/RowView.tsx
@@ -1,24 +1,30 @@
+import { useMemo } from 'react';
 import type { Row, TimeRange } from '../types';
 import { GraphPanel } from './GraphPanel';
 import { MarkdownPanel } from './MarkdownPanel';
 import { useQuery } from '../hooks/useQuery';
+import { substituteVariables } from '../utils/variables';
 
 interface RowViewProps {
   row: Row;
   rowIndex: number;
   timeRange: TimeRange;
   columns: number;
+  variableValues?: Record<string, string>;
 }
 
-export function RowView({ row, rowIndex, timeRange, columns }: RowViewProps) {
+export function RowView({ row, rowIndex, timeRange, columns, variableValues }: RowViewProps) {
+  const vars = variableValues || {};
+  const title = substituteVariables(row.title, vars);
+
   return (
     <div className="row">
-      <h2 className="row-title">{row.title}</h2>
+      <h2 className="row-title">{title}</h2>
       <div className="row-panels" style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}>
         {row.panels.map((panel, idx) => {
           const panelId = `panel-${rowIndex}-${idx}`;
           return (
-            <PanelRenderer key={idx} panel={panel} panelId={panelId} timeRange={timeRange} />
+            <PanelRenderer key={idx} panel={panel} panelId={panelId} timeRange={timeRange} variableValues={vars} />
           );
         })}
       </div>
@@ -30,21 +36,32 @@ interface PanelRendererProps {
   panel: Row['panels'][0];
   panelId: string;
   timeRange: TimeRange;
+  variableValues: Record<string, string>;
 }
 
-function PanelRenderer({ panel, panelId, timeRange }: PanelRendererProps) {
+function PanelRenderer({ panel, panelId, timeRange, variableValues }: PanelRendererProps) {
+  const substitutedTitle = substituteVariables(panel.title, variableValues);
+  const substitutedQuery = useMemo(
+    () => panel.query ? substituteVariables(panel.query, variableValues) : undefined,
+    [panel.query, variableValues],
+  );
+  const substitutedContent = useMemo(
+    () => panel.content ? substituteVariables(panel.content, variableValues) : undefined,
+    [panel.content, variableValues],
+  );
+
   const { data, loading, error } = useQuery(
-    panel.type === 'graph' ? panel.query : undefined,
+    panel.type === 'graph' ? substitutedQuery : undefined,
     timeRange,
   );
 
   if (panel.type === 'markdown') {
-    return <MarkdownPanel title={panel.title} content={panel.content || ''} id={panelId} />;
+    return <MarkdownPanel title={substitutedTitle} content={substitutedContent || ''} id={panelId} />;
   }
 
   return (
     <GraphPanel
-      title={panel.title}
+      title={substitutedTitle}
       data={data}
       unit={panel.unit}
       legend={panel.legend}

--- a/frontend/src/components/VariableBar.tsx
+++ b/frontend/src/components/VariableBar.tsx
@@ -1,0 +1,37 @@
+import type { VariableState } from '../hooks/useVariables';
+
+interface VariableBarProps {
+  variables: VariableState[];
+  onValueChange: (name: string, value: string) => void;
+}
+
+export function VariableBar({ variables, onValueChange }: VariableBarProps) {
+  if (variables.length === 0) return null;
+
+  return (
+    <div className="variable-bar">
+      {variables.map((variable) => (
+        <div key={variable.name} className="variable-selector">
+          <label className="variable-label">{variable.label}</label>
+          {variable.loading ? (
+            <span className="variable-loading">Loading...</span>
+          ) : variable.error ? (
+            <span className="variable-error">{variable.error}</span>
+          ) : (
+            <select
+              className="variable-select"
+              value={variable.selected}
+              onChange={(e) => onValueChange(variable.name, e.target.value)}
+            >
+              {variable.values.map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useVariables.ts
+++ b/frontend/src/hooks/useVariables.ts
@@ -1,0 +1,103 @@
+import { useState, useEffect } from 'react';
+import type { Variable } from '../types';
+import { fetchLabelValues, ApiError } from '../api/client';
+import { parseLabelValuesQuery } from '../utils/variables';
+
+export interface VariableState {
+  name: string;
+  label: string;
+  values: string[];
+  selected: string;
+  loading: boolean;
+  error: string | null;
+}
+
+interface UseVariablesResult {
+  variables: VariableState[];
+  selectedValues: Record<string, string>;
+  allValues: Record<string, string[]>;
+  setVariableValue: (name: string, value: string) => void;
+  loading: boolean;
+}
+
+export function useVariables(
+  definitions: Variable[] | undefined,
+  onAuthError: () => void,
+): UseVariablesResult {
+  const [variables, setVariables] = useState<VariableState[]>([]);
+
+  useEffect(() => {
+    if (!definitions || definitions.length === 0) {
+      setVariables([]);
+      return;
+    }
+
+    // Initialize variable states
+    const initial: VariableState[] = definitions.map((def) => ({
+      name: def.name,
+      label: def.label || def.name,
+      values: [],
+      selected: '',
+      loading: true,
+      error: null,
+    }));
+    setVariables(initial);
+
+    // Fetch all variable values in parallel
+    definitions.forEach((def, idx) => {
+      const parsed = parseLabelValuesQuery(def.query);
+      if (!parsed) {
+        setVariables((prev) => {
+          const next = [...prev];
+          next[idx] = { ...next[idx], loading: false, error: 'Invalid query format' };
+          return next;
+        });
+        return;
+      }
+
+      fetchLabelValues(parsed.label, parsed.metric)
+        .then((resp) => {
+          const values = resp.data || [];
+          setVariables((prev) => {
+            const next = [...prev];
+            next[idx] = {
+              ...next[idx],
+              values,
+              selected: values[0] || '',
+              loading: false,
+            };
+            return next;
+          });
+        })
+        .catch((err) => {
+          if (err instanceof ApiError && err.status === 401) {
+            onAuthError();
+          }
+          setVariables((prev) => {
+            const next = [...prev];
+            next[idx] = { ...next[idx], loading: false, error: err.message };
+            return next;
+          });
+        });
+    });
+  }, [definitions, onAuthError]);
+
+  const setVariableValue = (name: string, value: string) => {
+    setVariables((prev) =>
+      prev.map((v) => (v.name === name ? { ...v, selected: value } : v)),
+    );
+  };
+
+  const selectedValues: Record<string, string> = {};
+  const allValues: Record<string, string[]> = {};
+  for (const v of variables) {
+    if (v.selected) {
+      selectedValues[v.name] = v.selected;
+    }
+    allValues[v.name] = v.values;
+  }
+
+  const loading = variables.some((v) => v.loading);
+
+  return { variables, selectedValues, allValues, setVariableValue, loading };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -206,6 +206,56 @@ body {
   tab-size: 2;
 }
 
+/* Variable Bar */
+.variable-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 10px 16px;
+  margin-bottom: 16px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
+
+.variable-selector {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.variable-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.variable-select {
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.variable-select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.variable-loading,
+.variable-error {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.variable-error {
+  color: var(--color-error);
+}
+
 /* Row */
 .row {
   margin-bottom: 24px;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,13 +10,26 @@ export interface Panel {
 
 export interface Row {
   title: string;
+  repeat?: string;
   panels: Panel[];
+}
+
+export interface Variable {
+  name: string;
+  label?: string;
+  query: string;
 }
 
 export interface Dashboard {
   title: string;
+  variables?: Variable[];
   rows: Row[];
   path: string;
+}
+
+export interface LabelValuesResponse {
+  status: string;
+  data: string[];
 }
 
 export interface DashboardListItem {

--- a/frontend/src/utils/variables.ts
+++ b/frontend/src/utils/variables.ts
@@ -1,0 +1,33 @@
+/**
+ * Parses a label_values(metric, label) query string.
+ * Returns the metric and label, or null if the format doesn't match.
+ */
+export function parseLabelValuesQuery(query: string): { metric: string; label: string } | null {
+  const match = query.match(/^label_values\(\s*([^,]+?)\s*,\s*([^)]+?)\s*\)$/);
+  if (!match) return null;
+  return { metric: match[1], label: match[2] };
+}
+
+/**
+ * Substitutes template variables in a string.
+ * Replaces ${var} and $var patterns with their values.
+ * Processes longer variable names first to avoid prefix collisions.
+ */
+export function substituteVariables(template: string, variables: Record<string, string>): string {
+  if (!template || Object.keys(variables).length === 0) return template;
+
+  let result = template;
+
+  // Sort variable names by length descending to avoid prefix collisions
+  const names = Object.keys(variables).sort((a, b) => b.length - a.length);
+
+  for (const name of names) {
+    const value = variables[name];
+    // Replace ${var} form
+    result = result.split(`\${${name}}`).join(value);
+    // Replace $var form (only when not followed by word characters to avoid partial matches)
+    result = result.replace(new RegExp(`\\$${name}(?![a-zA-Z0-9_])`, 'g'), value);
+  }
+
+  return result;
+}

--- a/internal/handler/label_values.go
+++ b/internal/handler/label_values.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tokuhirom/dashyard/internal/prometheus"
+)
+
+// LabelValuesHandler handles GET /api/label-values - proxies label values requests to Prometheus.
+type LabelValuesHandler struct {
+	client *prometheus.Client
+}
+
+// NewLabelValuesHandler creates a new LabelValuesHandler.
+func NewLabelValuesHandler(client *prometheus.Client) *LabelValuesHandler {
+	return &LabelValuesHandler{client: client}
+}
+
+// Handle processes a Prometheus label values proxy request.
+func (h *LabelValuesHandler) Handle(c *gin.Context) {
+	label := c.Query("label")
+	if label == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "label parameter is required"})
+		return
+	}
+
+	match := c.Query("match")
+
+	body, statusCode, err := h.client.LabelValues(c.Request.Context(), label, match)
+	if err != nil {
+		slog.Error("prometheus label values query failed", "error", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "prometheus label values query failed"})
+		return
+	}
+	defer body.Close()
+
+	c.Header("Content-Type", "application/json")
+	c.Status(statusCode)
+	if _, err := io.Copy(c.Writer, body); err != nil {
+		slog.Error("failed to stream prometheus response", "error", err)
+	}
+}

--- a/internal/handler/label_values_test.go
+++ b/internal/handler/label_values_test.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tokuhirom/dashyard/internal/prometheus"
+)
+
+func TestLabelValuesHandler(t *testing.T) {
+	promServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"success","data":["eth0","eth1"]}`))
+	}))
+	defer promServer.Close()
+
+	client := prometheus.NewClient(promServer.URL, 5*time.Second)
+	handler := NewLabelValuesHandler(client)
+
+	router := gin.New()
+	router.GET("/api/label-values", handler.Handle)
+
+	req := httptest.NewRequest("GET", "/api/label-values?label=device&match=system_network_io_bytes_total", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	expected := `{"status":"success","data":["eth0","eth1"]}`
+	if resp.Body.String() != expected {
+		t.Errorf("expected body %q, got %q", expected, resp.Body.String())
+	}
+}
+
+func TestLabelValuesHandlerMissingLabel(t *testing.T) {
+	client := prometheus.NewClient("http://localhost:9090", 5*time.Second)
+	handler := NewLabelValuesHandler(client)
+
+	router := gin.New()
+	router.GET("/api/label-values", handler.Handle)
+
+	req := httptest.NewRequest("GET", "/api/label-values", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.Code)
+	}
+}
+
+func TestLabelValuesHandlerPrometheusError(t *testing.T) {
+	promServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"status":"error","error":"internal error"}`))
+	}))
+	defer promServer.Close()
+
+	client := prometheus.NewClient(promServer.URL, 5*time.Second)
+	handler := NewLabelValuesHandler(client)
+
+	router := gin.New()
+	router.GET("/api/label-values", handler.Handle)
+
+	req := httptest.NewRequest("GET", "/api/label-values?label=device", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.Code)
+	}
+}

--- a/internal/model/dashboard.go
+++ b/internal/model/dashboard.go
@@ -14,14 +14,23 @@ type Panel struct {
 // Row represents a horizontal row of panels in a dashboard.
 type Row struct {
 	Title  string  `yaml:"title" json:"title"`
+	Repeat string  `yaml:"repeat,omitempty" json:"repeat,omitempty"`
 	Panels []Panel `yaml:"panels" json:"panels"`
+}
+
+// Variable represents a dashboard-level template variable populated from Prometheus label values.
+type Variable struct {
+	Name  string `yaml:"name" json:"name"`
+	Label string `yaml:"label,omitempty" json:"label,omitempty"`
+	Query string `yaml:"query" json:"query"`
 }
 
 // Dashboard represents a single dashboard definition loaded from YAML.
 type Dashboard struct {
-	Title string `yaml:"title" json:"title"`
-	Rows  []Row  `yaml:"rows" json:"rows"`
-	Path  string `yaml:"-" json:"path"` // Set by loader, not from YAML
+	Title     string     `yaml:"title" json:"title"`
+	Variables []Variable `yaml:"variables,omitempty" json:"variables,omitempty"`
+	Rows      []Row      `yaml:"rows" json:"rows"`
+	Path      string     `yaml:"-" json:"path"` // Set by loader, not from YAML
 }
 
 // DashboardTreeNode represents a node in the hierarchical dashboard navigation tree.

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -53,3 +53,31 @@ func (c *Client) QueryRange(ctx context.Context, query, start, end, step string)
 
 	return resp.Body, resp.StatusCode, nil
 }
+
+// LabelValues queries the Prometheus label values API and returns the raw response body.
+// The caller is responsible for closing the returned ReadCloser.
+func (c *Client) LabelValues(ctx context.Context, label, match string) (io.ReadCloser, int, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, 0, fmt.Errorf("parsing base URL: %w", err)
+	}
+	u.Path = fmt.Sprintf("/api/v1/label/%s/values", label)
+
+	if match != "" {
+		params := url.Values{}
+		params.Set("match[]", match)
+		u.RawQuery = params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("executing request: %w", err)
+	}
+
+	return resp.Body, resp.StatusCode, nil
+}

--- a/internal/prometheus/client_test.go
+++ b/internal/prometheus/client_test.go
@@ -75,6 +75,71 @@ func TestQueryRangeServerError(t *testing.T) {
 	}
 }
 
+func TestLabelValues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/label/device/values" {
+			t.Errorf("expected path '/api/v1/label/device/values', got %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("match[]") != "system_network_io_bytes_total" {
+			t.Errorf("expected match[] 'system_network_io_bytes_total', got %q", r.URL.Query().Get("match[]"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"success","data":["eth0","eth1"]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, 5*time.Second)
+
+	body, statusCode, err := client.LabelValues(context.Background(), "device", "system_network_io_bytes_total")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer body.Close()
+
+	if statusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", statusCode)
+	}
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("unexpected error reading body: %v", err)
+	}
+	expected := `{"status":"success","data":["eth0","eth1"]}`
+	if string(data) != expected {
+		t.Errorf("expected body %q, got %q", expected, string(data))
+	}
+}
+
+func TestLabelValuesNoMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/label/cpu/values" {
+			t.Errorf("expected path '/api/v1/label/cpu/values', got %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("match[]") != "" {
+			t.Errorf("expected no match[] parameter, got %q", r.URL.Query().Get("match[]"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"success","data":["cpu0","cpu1"]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, 5*time.Second)
+
+	body, statusCode, err := client.LabelValues(context.Background(), "cpu", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer body.Close()
+
+	if statusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", statusCode)
+	}
+}
+
 func TestQueryRangeConnectionError(t *testing.T) {
 	client := NewClient("http://localhost:1", 1*time.Second)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,7 @@ func New(cfg *config.Config, holder *dashboard.StoreHolder, frontendFS fs.FS) *h
 	loginHandler := handler.NewLoginHandler(cfg.Users, sm)
 	dashboardsHandler := handler.NewDashboardsHandler(holder, cfg.SiteTitle, cfg.HeaderColor)
 	queryHandler := handler.NewQueryHandler(promClient)
+	labelValuesHandler := handler.NewLabelValuesHandler(promClient)
 	staticHandler := handler.NewStaticHandler(frontendFS)
 
 	// Public routes
@@ -44,6 +45,7 @@ func New(cfg *config.Config, holder *dashboard.StoreHolder, frontendFS fs.FS) *h
 		api.GET("/dashboards/*path", dashboardsHandler.Get)
 		api.GET("/dashboard-source/*path", dashboardsHandler.GetSource)
 		api.GET("/query", queryHandler.Handle)
+		api.GET("/label-values", labelValuesHandler.Handle)
 	}
 
 	// Frontend static files (SPA fallback)

--- a/schemas/dashboard.schema.json
+++ b/schemas/dashboard.schema.json
@@ -9,6 +9,13 @@
       "type": "string",
       "description": "Display title of the dashboard."
     },
+    "variables": {
+      "type": "array",
+      "description": "Template variables populated from Prometheus label values.",
+      "items": {
+        "$ref": "#/$defs/variable"
+      }
+    },
     "rows": {
       "type": "array",
       "description": "Horizontal rows of panels.",
@@ -20,6 +27,26 @@
   "required": ["title", "rows"],
   "additionalProperties": false,
   "$defs": {
+    "variable": {
+      "type": "object",
+      "description": "A template variable populated from Prometheus label values.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Variable name used in PromQL templates as $name or ${name}."
+        },
+        "label": {
+          "type": "string",
+          "description": "Display label for the variable dropdown. Defaults to name if omitted."
+        },
+        "query": {
+          "type": "string",
+          "description": "Query to populate values, e.g. label_values(metric, label)."
+        }
+      },
+      "required": ["name", "query"],
+      "additionalProperties": false
+    },
     "row": {
       "type": "object",
       "description": "A horizontal row containing one or more panels.",
@@ -27,6 +54,10 @@
         "title": {
           "type": "string",
           "description": "Display title of the row."
+        },
+        "repeat": {
+          "type": "string",
+          "description": "Variable name to repeat this row for each value of the variable."
         },
         "panels": {
           "type": "array",


### PR DESCRIPTION
## Summary
- Add Grafana-style template variables populated from Prometheus `label_values()` queries, with dropdown selectors and client-side `$var`/`${var}` substitution in PromQL, titles, and markdown content
- Add repeat rows: rows with `repeat: var_name` are duplicated for each value of that variable
- Add `/api/label-values` proxy endpoint (backend) and label values endpoint to dummyprom

## Changes

**Backend (Go)**
- `internal/model/dashboard.go` — `Variable` struct, `Variables` on Dashboard, `Repeat` on Row
- `internal/prometheus/client.go` — `LabelValues()` method
- `internal/handler/label_values.go` — New proxy handler for label values
- `internal/server/server.go` — Wire `/api/label-values` route
- `cmd/dummyprom/main.go` — `/api/v1/label/{label}/values` with hardcoded label registry

**Frontend (React/TypeScript)**
- `frontend/src/types/index.ts` — `Variable`, `LabelValuesResponse` types
- `frontend/src/api/client.ts` — `fetchLabelValues()` API function
- `frontend/src/utils/variables.ts` — `parseLabelValuesQuery()` and `substituteVariables()` utilities
- `frontend/src/hooks/useVariables.ts` — Variable state management hook
- `frontend/src/components/VariableBar.tsx` — Dropdown selector bar component
- `frontend/src/components/DashboardView.tsx` — Variable bar rendering + repeat row expansion
- `frontend/src/components/RowView.tsx` — Variable substitution in titles, queries, and content
- `frontend/src/index.css` — Variable bar styles

**Schema & Examples**
- `schemas/dashboard.schema.json` — `variables` array and `repeat` field
- `examples/dashboards/network-variable.yaml` — Single device selector dashboard
- `examples/dashboards/network-repeat.yaml` — Repeat-row-per-device dashboard

## Test plan
- [x] `go test ./...` — All backend tests pass (model, prometheus client, handler)
- [x] `cd frontend && npm run build` — TypeScript compiles and Vite builds
- [x] Playwright e2e: variable dropdown loads values, substitution works, switching values updates UI
- [x] Playwright e2e: repeat rows expand (one per device), panel titles contain substituted values
- [x] All 18 existing + new e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)