### PR TITLE
Fix CI lint job: build frontend before linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build frontend
+        run: cd frontend && npm ci && npm run build
       - uses: golangci/golangci-lint-action@v9
 
   backend:


### PR DESCRIPTION
## Summary

- Add frontend build step (setup-node + npm ci + npm run build) to the CI lint job

The `go:embed frontend/dist/*` directive in `main.go` requires the built frontend files to exist. Without them, golangci-lint fails with a `typecheck` error:

```
main.go:22:12: pattern frontend/dist/*: no matching files found (typecheck)
```

## Test plan

- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)