### PR TITLE
Move host/port from config file to CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ site_title: "My Monitoring"    # Optional, defaults to "Dashyard"
 header_color: "#dc2626"        # Optional, any CSS color value
 
 server:
-  host: "0.0.0.0"
-  port: 8080
   session_secret: "change-me-in-production"
 
 prometheus:
@@ -113,6 +111,12 @@ dashboards:
 users:
   - id: "admin"
     password_hash: "$6$..."
+```
+
+Host and port are set via CLI flags (defaults: `0.0.0.0:8080`):
+
+```bash
+./dashyard serve --config config.yaml --host 127.0.0.1 --port 9090
 ```
 
 Generate a password hash:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,8 +2,6 @@ site_title: "My Dashyard"
 # header_color: "#dc2626"
 
 server:
-  host: "0.0.0.0"
-  port: 8080
   session_secret: "change-me-in-production"
 
 prometheus:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,8 +18,6 @@ type User struct {
 
 // ServerConfig holds HTTP server settings.
 type ServerConfig struct {
-	Host          string `yaml:"host"`
-	Port          int    `yaml:"port"`
 	SessionSecret string `yaml:"session_secret"`
 }
 
@@ -57,10 +55,6 @@ func Load(path string) (*Config, error) {
 func Parse(data []byte) (*Config, error) {
 	cfg := &Config{
 		SiteTitle: "Dashyard",
-		Server: ServerConfig{
-			Host: "0.0.0.0",
-			Port: 8080,
-		},
 		Prometheus: PrometheusConfig{
 			URL:     "http://localhost:9090",
 			Timeout: 30 * time.Second,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,8 +11,6 @@ site_title: "My Monitoring"
 header_color: "#dc2626"
 
 server:
-  host: "127.0.0.1"
-  port: 9090
   session_secret: "my-secret"
 
 prometheus:
@@ -39,12 +37,6 @@ users:
 	}
 	if cfg.HeaderColor != "#dc2626" {
 		t.Errorf("expected header_color '#dc2626', got %q", cfg.HeaderColor)
-	}
-	if cfg.Server.Host != "127.0.0.1" {
-		t.Errorf("expected host '127.0.0.1', got %q", cfg.Server.Host)
-	}
-	if cfg.Server.Port != 9090 {
-		t.Errorf("expected port 9090, got %d", cfg.Server.Port)
 	}
 	if cfg.Server.SessionSecret != "my-secret" {
 		t.Errorf("expected session_secret 'my-secret', got %q", cfg.Server.SessionSecret)
@@ -79,12 +71,6 @@ func TestParseDefaults(t *testing.T) {
 	}
 	if cfg.HeaderColor != "" {
 		t.Errorf("expected default header_color '', got %q", cfg.HeaderColor)
-	}
-	if cfg.Server.Host != "0.0.0.0" {
-		t.Errorf("expected default host '0.0.0.0', got %q", cfg.Server.Host)
-	}
-	if cfg.Server.Port != 8080 {
-		t.Errorf("expected default port 8080, got %d", cfg.Server.Port)
 	}
 	if cfg.Prometheus.URL != "http://localhost:9090" {
 		t.Errorf("expected default prometheus url, got %q", cfg.Prometheus.URL)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,7 +14,7 @@ import (
 )
 
 // New creates and configures an http.Server with all routes and middleware.
-func New(cfg *config.Config, holder *dashboard.StoreHolder, frontendFS fs.FS) *http.Server {
+func New(cfg *config.Config, holder *dashboard.StoreHolder, frontendFS fs.FS, host string, port int) *http.Server {
 	gin.SetMode(gin.ReleaseMode)
 
 	r := gin.New()
@@ -51,7 +51,7 @@ func New(cfg *config.Config, holder *dashboard.StoreHolder, frontendFS fs.FS) *h
 	// Frontend static files (SPA fallback)
 	r.NoRoute(staticHandler.Handle)
 
-	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
+	addr := fmt.Sprintf("%s:%d", host, port)
 
 	return &http.Server{
 		Addr:    addr,

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ var cli struct {
 
 type ServeCmd struct {
 	Config string `help:"Path to config file." default:"config.yaml"`
+	Host   string `help:"Host to listen on." default:"0.0.0.0"`
+	Port   int    `help:"Port to listen on." default:"8080"`
 }
 
 func (cmd *ServeCmd) Run() error {
@@ -57,7 +59,7 @@ func (cmd *ServeCmd) Run() error {
 	}
 
 	// Create server
-	srv := server.New(cfg, holder, frontendFS)
+	srv := server.New(cfg, holder, frontendFS, cmd.Host, cmd.Port)
 
 	// Graceful shutdown
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -19,18 +19,6 @@
       "type": "object",
       "description": "HTTP server settings.",
       "properties": {
-        "host": {
-          "type": "string",
-          "description": "Bind address for the HTTP server.",
-          "default": "0.0.0.0"
-        },
-        "port": {
-          "type": "integer",
-          "description": "Port number for the HTTP server.",
-          "default": 8080,
-          "minimum": 1,
-          "maximum": 65535
-        },
         "session_secret": {
           "type": "string",
           "description": "Secret key for session signing. Auto-generated if omitted."


### PR DESCRIPTION
## Summary

- Move `host` and `port` out of `config.yaml` server section into `--host` and `--port` CLI flags on the `serve` subcommand
- These are deployment-specific settings that are more natural as CLI flags (defaults unchanged: `0.0.0.0:8080`)
- Remove host/port from config struct, JSON schema, example config, and tests

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `./dashyard serve --help` shows `--host` and `--port` flags with correct defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)