### PR TITLE
Support y_min and y_max on graph panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ rows:
 
 | Type | Required Fields | Optional Fields |
 |------|----------------|-----------------|
-| `graph` | `title`, `type`, `query` | `chart_type`, `unit`, `legend` |
+| `graph` | `title`, `type`, `query` | `chart_type`, `unit`, `legend`, `y_min`, `y_max` |
 | `markdown` | `title`, `type`, `content` | -- |
 
 ### `chart_type`
@@ -210,8 +210,20 @@ Controls y-axis value formatting.
 | Value | Description |
 |-------|-------------|
 | `bytes` | Human-readable byte sizes (e.g. `1.5 GB`) |
-| `percent` | Percentage with one decimal (e.g. `75.0%`). Y-axis is fixed to 0–100. |
+| `percent` | Percentage with one decimal (e.g. `75.0%`). Y-axis is fixed to 0–100 unless overridden by `y_min`/`y_max`. |
 | `count` | Numeric with SI suffixes (e.g. `1.2k`). This is also the default when `unit` is omitted. |
+
+### `y_min` / `y_max`
+
+Set explicit Y-axis bounds. These override the automatic scaling and any unit-based defaults (e.g. the 0–100 range for `unit: percent`). Both fields are optional and can be used independently.
+
+```yaml
+- title: "Temperature"
+  type: "graph"
+  query: 'sensor_temperature_celsius'
+  y_min: -20
+  y_max: 50
+```
 
 ### `legend`
 

--- a/examples/dashboards/y-axis-bounds.yaml
+++ b/examples/dashboards/y-axis-bounds.yaml
@@ -1,0 +1,26 @@
+title: "Y-Axis Bounds Demo"
+rows:
+  - title: "Custom Y-Axis Range"
+    panels:
+      - title: "CPU (default 0–100 for percent)"
+        type: "graph"
+        query: "system_cpu_utilization_ratio"
+        unit: "percent"
+      - title: "CPU (y_max override to 50)"
+        type: "graph"
+        query: "system_cpu_utilization_ratio"
+        unit: "percent"
+        y_max: 50
+  - title: "Explicit Bounds"
+    panels:
+      - title: "Load Average (y_min: 0, y_max: 10)"
+        type: "graph"
+        query: "system_cpu_load_average_1m_ratio"
+        unit: "count"
+        y_min: 0
+        y_max: 10
+      - title: "Memory (y_min only)"
+        type: "graph"
+        query: 'system_memory_usage_bytes{state="used"}'
+        unit: "bytes"
+        y_min: 0

--- a/frontend/src/components/GraphPanel.tsx
+++ b/frontend/src/components/GraphPanel.tsx
@@ -35,6 +35,8 @@ interface GraphPanelProps {
   title: string;
   data: PrometheusResponse | null;
   unit?: string;
+  yMin?: number;
+  yMax?: number;
   legend?: string;
   chartType?: 'line' | 'bar' | 'area' | 'scatter' | 'pie' | 'doughnut';
   loading: boolean;
@@ -58,7 +60,7 @@ function buildLabel(metric: Record<string, string>, legend?: string): string {
   return entries.map(([k, v]) => `${k}="${v}"`).join(', ');
 }
 
-export function GraphPanel({ title, data, unit, legend, chartType, loading, error, id }: GraphPanelProps) {
+export function GraphPanel({ title, data, unit, yMin, yMax, legend, chartType, loading, error, id }: GraphPanelProps) {
   const titleContent = (
     <h3 className="panel-title">
       {title}
@@ -185,6 +187,8 @@ export function GraphPanel({ title, data, unit, legend, chartType, loading, erro
       y: {
         beginAtZero: true,
         ...(unit === 'percent' ? { min: 0, max: 100 } : {}),
+        ...(yMin !== undefined ? { min: yMin } : {}),
+        ...(yMax !== undefined ? { max: yMax } : {}),
         ticks: {
           callback: tickCallback,
         },

--- a/frontend/src/components/RowView.tsx
+++ b/frontend/src/components/RowView.tsx
@@ -64,6 +64,8 @@ function PanelRenderer({ panel, panelId, timeRange, variableValues }: PanelRende
       title={substitutedTitle}
       data={data}
       unit={panel.unit}
+      yMin={panel.y_min}
+      yMax={panel.y_max}
       legend={panel.legend}
       chartType={panel.chart_type}
       loading={loading}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,8 @@ export interface Panel {
   chart_type?: 'line' | 'bar' | 'area' | 'scatter' | 'pie' | 'doughnut';
   query?: string;
   unit?: 'bytes' | 'percent' | 'count';
+  y_min?: number;
+  y_max?: number;
   legend?: string;
   content?: string;
 }

--- a/internal/model/dashboard.go
+++ b/internal/model/dashboard.go
@@ -6,9 +6,11 @@ type Panel struct {
 	Type      string `yaml:"type" json:"type"`       // "graph" or "markdown"
 	ChartType string `yaml:"chart_type,omitempty" json:"chart_type,omitempty"`
 	Query     string `yaml:"query,omitempty" json:"query,omitempty"`
-	Unit      string `yaml:"unit,omitempty" json:"unit,omitempty"` // "bytes", "percent", "count"
-	Legend    string `yaml:"legend,omitempty" json:"legend,omitempty"`
-	Content   string `yaml:"content,omitempty" json:"content,omitempty"`
+	Unit      string   `yaml:"unit,omitempty" json:"unit,omitempty"` // "bytes", "percent", "count"
+	YMin      *float64 `yaml:"y_min,omitempty" json:"y_min,omitempty"`
+	YMax      *float64 `yaml:"y_max,omitempty" json:"y_max,omitempty"`
+	Legend    string   `yaml:"legend,omitempty" json:"legend,omitempty"`
+	Content   string   `yaml:"content,omitempty" json:"content,omitempty"`
 }
 
 // Row represents a horizontal row of panels in a dashboard.

--- a/schemas/dashboard.schema.json
+++ b/schemas/dashboard.schema.json
@@ -107,6 +107,14 @@
         "legend": {
           "type": "string",
           "description": "Go template string for formatting legend labels. Metric label names can be used as placeholders (e.g. \"{{device}} {{direction}}\")."
+        },
+        "y_min": {
+          "type": "number",
+          "description": "Explicit minimum value for the Y axis. Overrides unit-based defaults (e.g. 0 for percent)."
+        },
+        "y_max": {
+          "type": "number",
+          "description": "Explicit maximum value for the Y axis. Overrides unit-based defaults (e.g. 100 for percent)."
         }
       },
       "required": ["title", "type", "query"],


### PR DESCRIPTION
## Summary
- Add optional `y_min` and `y_max` fields to graph panels, allowing dashboard authors to set explicit y-axis bounds
- Explicit values override auto-scaling and unit-based defaults (e.g. the 0–100 range for `unit: percent`)
- Both fields are optional and can be used independently

## Changes
- **`internal/model/dashboard.go`** — Add `YMin` and `YMax` as `*float64` to the `Panel` struct
- **`frontend/src/types/index.ts`** — Add `y_min` and `y_max` to `Panel` interface
- **`frontend/src/components/GraphPanel.tsx`** — Apply `yMin`/`yMax` to Chart.js y-axis config (with priority over unit defaults)
- **`frontend/src/components/RowView.tsx`** — Pass `y_min`/`y_max` props through to `GraphPanel`
- **`schemas/dashboard.schema.json`** — Add `y_min` and `y_max` to graphPanel properties
- **`README.md`** — Document the new fields
- **`examples/dashboards/y-axis-bounds.yaml`** — Sample dashboard demonstrating the feature

## Test plan
- [x] `go test ./...` passes
- [x] `cd frontend && npm run build` succeeds (TypeScript + Vite)
- [ ] Load the `y-axis-bounds.yaml` example dashboard and verify axis bounds render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)