### PR TITLE
Fix Go version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker compose -f examples/docker-compose.yaml up
 
 ### Build from source
 
-Requires Go 1.23+ and Node.js 20+.
+Requires Go 1.25+ and Node.js 20+.
 
 ```bash
 git clone https://github.com/tokuhirom/dashyard.git


### PR DESCRIPTION
## Summary

- Update README "Build from source" section from "Go 1.23+" to "Go 1.25+" to match the `go 1.25.5` directive in `go.mod`

Closes #45

## Test plan

- [ ] Verify README shows correct Go version requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)