### PR TITLE
Add issue linking convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ cd frontend && npm run build     # Type-checks and builds frontend
 - When starting a new task, always pull the latest main and create a new branch from it first (`git checkout main && git pull origin main && git checkout -b <branch>`)
 - Create a separate branch and pull request for each feature or change
 - Do not mix unrelated changes in a single branch/PR
+- Include a link to the related issue in PR descriptions (e.g. `Fixes #123`)
 
 ## Go Module
 


### PR DESCRIPTION
## Summary
- Add a note to the Git Workflow section in CLAUDE.md requiring PR descriptions to include a link to the related issue (e.g. `Fixes #123`)

## Test plan
- [x] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)