### PR TITLE
Add validate subcommand

### DIFF
--- a/internal/dashboard/loader.go
+++ b/internal/dashboard/loader.go
@@ -64,6 +64,9 @@ func LoadDir(dir string) (*Store, error) {
 		if err := yaml.Unmarshal(data, &d); err != nil {
 			return fmt.Errorf("parsing %s: %w", path, err)
 		}
+		if err := d.Validate(); err != nil {
+			return fmt.Errorf("validating %s: %w", path, err)
+		}
 		d.Path = dashPath
 
 		store.dashboards[dashPath] = &d

--- a/internal/dashboard/watcher_test.go
+++ b/internal/dashboard/watcher_test.go
@@ -10,7 +10,8 @@ import (
 
 const validDashboardYAML = `title: Test Dashboard
 rows:
-  - panels:
+  - title: Test Row
+    panels:
       - title: Test Panel
         type: markdown
         content: hello

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var frontendFiles embed.FS
 
 var cli struct {
 	Serve    ServeCmd    `cmd:"" help:"Start the dashboard server."`
+	Validate ValidateCmd `cmd:"" help:"Validate config and dashboard files."`
 	Mkpasswd MkpasswdCmd `cmd:"" help:"Generate a SHA-512 crypt password hash."`
 }
 
@@ -95,6 +96,26 @@ func (cmd *ServeCmd) Run() error {
 		slog.Error("shutdown error", "error", err)
 	}
 	slog.Info("server stopped")
+	return nil
+}
+
+type ValidateCmd struct {
+	Config string `help:"Path to config file." default:"config.yaml"`
+}
+
+func (cmd *ValidateCmd) Run() error {
+	cfg, err := config.Load(cmd.Config)
+	if err != nil {
+		return fmt.Errorf("config %s: %w", cmd.Config, err)
+	}
+	fmt.Printf("Config OK: %s\n", cmd.Config)
+
+	store, err := dashboard.LoadDir(cfg.Dashboards.Dir)
+	if err != nil {
+		return fmt.Errorf("dashboards: %w", err)
+	}
+	fmt.Printf("Dashboards OK: loaded %d dashboards from %q\n", len(store.List()), cfg.Dashboards.Dir)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Add `dashyard validate --config <path>` subcommand that validates config and dashboard YAML files
- Add `Dashboard.Validate()` method with semantic checks: title, rows, panels, variable names/queries, repeat references, valid chart types and units
- Integrate validation into `dashboard.LoadDir()` so invalid dashboards are caught at load time
- Add 18 test cases covering all validation rules

## Test plan
- [x] `go test ./...` passes
- [x] `go build ./...` succeeds
- [x] `dashyard validate --config examples/config.yaml` validates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)