### PR TITLE
Add seconds unit for duration/latency metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Controls y-axis value formatting.
 |-------|-------------|
 | `bytes` | Human-readable byte sizes (e.g. `1.5 GB`) |
 | `percent` | Percentage with one decimal (e.g. `75.0%`). Y-axis is fixed to 0–100 unless overridden by `y_min`/`y_max`. |
+| `seconds` | Human-readable time durations (e.g. `200ms`, `1.50s`, `2.5m`) |
 | `count` | Numeric with SI suffixes (e.g. `1.2k`). This is also the default when `unit` is omitted. |
 
 ### `y_min` / `y_max`

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,7 +9,7 @@ export interface Panel {
   type: 'graph' | 'markdown';
   chart_type?: 'line' | 'bar' | 'area' | 'scatter' | 'pie' | 'doughnut';
   query?: string;
-  unit?: 'bytes' | 'percent' | 'count';
+  unit?: 'bytes' | 'percent' | 'count' | 'seconds';
   y_min?: number;
   y_max?: number;
   legend?: string;

--- a/frontend/src/utils/units.ts
+++ b/frontend/src/utils/units.ts
@@ -15,12 +15,25 @@ export function formatCount(value: number): string {
   return value.toLocaleString('en-US', { maximumFractionDigits: 2 });
 }
 
+export function formatSeconds(value: number): string {
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  if (abs === 0) return '0s';
+  if (abs < 0.001) return `${sign}${(abs * 1_000_000).toFixed(0)}µs`;
+  if (abs < 1) return `${sign}${(abs * 1000).toFixed(1)}ms`;
+  if (abs < 60) return `${sign}${abs.toFixed(2)}s`;
+  if (abs < 3600) return `${sign}${(abs / 60).toFixed(1)}m`;
+  return `${sign}${(abs / 3600).toFixed(1)}h`;
+}
+
 export function formatValue(value: number, unit?: string): string {
   switch (unit) {
     case 'bytes':
       return formatBytes(value);
     case 'percent':
       return formatPercent(value);
+    case 'seconds':
+      return formatSeconds(value);
     case 'count':
       return formatCount(value);
     default:

--- a/internal/model/dashboard.go
+++ b/internal/model/dashboard.go
@@ -15,7 +15,7 @@ type Panel struct {
 	Type       string      `yaml:"type" json:"type"`       // "graph" or "markdown"
 	ChartType  string      `yaml:"chart_type,omitempty" json:"chart_type,omitempty"`
 	Query      string      `yaml:"query,omitempty" json:"query,omitempty"`
-	Unit       string      `yaml:"unit,omitempty" json:"unit,omitempty"` // "bytes", "percent", "count"
+	Unit       string      `yaml:"unit,omitempty" json:"unit,omitempty"` // "bytes", "percent", "count", "seconds"
 	YMin       *float64    `yaml:"y_min,omitempty" json:"y_min,omitempty"`
 	YMax       *float64    `yaml:"y_max,omitempty" json:"y_max,omitempty"`
 	Legend     string      `yaml:"legend,omitempty" json:"legend,omitempty"`

--- a/internal/model/dashboard_test.go
+++ b/internal/model/dashboard_test.go
@@ -592,7 +592,7 @@ func TestValidateGraphPanelInvalidUnit(t *testing.T) {
 }
 
 func TestValidateGraphPanelValidUnits(t *testing.T) {
-	for _, u := range []string{"bytes", "percent", "count"} {
+	for _, u := range []string{"bytes", "percent", "count", "seconds"} {
 		d := Dashboard{
 			Title: "Test",
 			Rows:  []Row{{Title: "Row1", Panels: []Panel{{Title: "P1", Type: "graph", Query: "up", Unit: u}}}},

--- a/schemas/dashboard.schema.json
+++ b/schemas/dashboard.schema.json
@@ -96,7 +96,7 @@
         "unit": {
           "type": "string",
           "description": "Unit for formatting values on the Y axis.",
-          "enum": ["bytes", "percent", "count"]
+          "enum": ["bytes", "percent", "count", "seconds"]
         },
         "chart_type": {
           "type": "string",


### PR DESCRIPTION
## Summary

- Add `"seconds"` to the `unit` enum in `schemas/dashboard.schema.json`
- Add `formatSeconds()` to frontend utils with human-readable formatting: `µs`, `ms`, `s`, `m`, `h`
- Add `'seconds'` to the frontend TypeScript union type
- Add `"seconds"` to the backend test coverage
- Update README unit documentation table

The backend `validUnits` map already included `"seconds"`, but the JSON schema, frontend types, and frontend formatter were missing it. LLM-generated dashboards for duration metrics (GC duration, request latency, disk I/O time) use `unit: seconds` and previously failed schema validation.

Formatting examples:
- `0.0003` → `300µs`
- `0.250` → `250.0ms`
- `1.5` → `1.50s`
- `90` → `1.5m`
- `7200` → `2.0h`

Fixes #64

## Test plan

- [x] `go test ./...` passes (including updated unit validation test)
- [x] `cd frontend && npm run build` passes
- [x] `dashyard validate --config examples/config.yaml` passes (includes `many-panels.yaml` with `unit: "seconds"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)