### PR TITLE
Add PromQL division-by-zero guard guidance

### DIFF
--- a/docs/gen-prompt/output/prompt.md
+++ b/docs/gen-prompt/output/prompt.md
@@ -203,6 +203,16 @@ rows:
 | `seconds` | durations, latencies | Human-readable time |
 | `count` | counts, rates, dimensionless (default when omitted) | SI suffixes (k, M) |
 
+## Division Queries
+
+When dividing two `rate()` expressions (e.g. hit rate = hits / (hits + misses)), guard against division by zero with `> 0` on the denominator. Without this, periods with no traffic produce `NaN`.
+
+```
+rate(hits_total[5m]) / (rate(hits_total[5m]) + rate(misses_total[5m]) > 0) * 100
+```
+
+The `> 0` filter drops zero-denominator samples so the panel shows no data instead of `NaN`.
+
 ## Stacked Charts
 
 Use `stacked: true` when series represent parts of a whole that sum to a meaningful total (e.g. memory by state: used + cached + free + buffers = total). Do not stack independent series that overlap (e.g. CPU utilization per core).

--- a/internal/prompt/format_reference.md
+++ b/internal/prompt/format_reference.md
@@ -60,6 +60,16 @@ rows:
 | `seconds` | durations, latencies | Human-readable time |
 | `count` | counts, rates, dimensionless (default when omitted) | SI suffixes (k, M) |
 
+## Division Queries
+
+When dividing two `rate()` expressions (e.g. hit rate = hits / (hits + misses)), guard against division by zero with `> 0` on the denominator. Without this, periods with no traffic produce `NaN`.
+
+```
+rate(hits_total[5m]) / (rate(hits_total[5m]) + rate(misses_total[5m]) > 0) * 100
+```
+
+The `> 0` filter drops zero-denominator samples so the panel shows no data instead of `NaN`.
+
 ## Stacked Charts
 
 Use `stacked: true` when series represent parts of a whole that sum to a meaningful total (e.g. memory by state: used + cached + free + buffers = total). Do not stack independent series that overlap (e.g. CPU utilization per core).


### PR DESCRIPTION
## Summary

- Add a "Division Queries" section to `internal/prompt/format_reference.md` with guidance on guarding against division by zero in PromQL ratio queries
- Update the generated `docs/gen-prompt/output/prompt.md` to match

When dividing two `rate()` expressions (e.g. Redis keyspace hit rate), the denominator can be zero during periods with no traffic, producing `NaN`. The recommended pattern uses `> 0` on the denominator to drop zero-value samples:

```promql
rate(hits_total[5m]) / (rate(hits_total[5m]) + rate(misses_total[5m]) > 0) * 100
```

This causes the panel to show no data instead of `NaN` when there is no activity.

Fixes #67

## Test plan

- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)