### PR TITLE
Fix gen-prompt: force rebuild Docker image before run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ gen-prompt:
 	docker compose -f docs/gen-prompt/docker-compose.yaml up -d prometheus otelcol traefik redis whoami traffic-gen
 	@echo "Waiting 60s for metrics to accumulate..."
 	@sleep 60
+	docker compose -f docs/gen-prompt/docker-compose.yaml build gen-prompt
 	docker compose -f docs/gen-prompt/docker-compose.yaml run --rm gen-prompt
 	docker compose -f docs/gen-prompt/docker-compose.yaml down
 

--- a/docs/gen-prompt/docker-compose.yaml
+++ b/docs/gen-prompt/docker-compose.yaml
@@ -95,6 +95,7 @@ services:
       - http://prometheus:9090
       - -o
       - /output
+      - --force-prompt
     depends_on:
       prometheus:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Add explicit `docker compose build gen-prompt` before `run` in the Makefile

The gen-prompt Docker image can use a stale cached binary when code changes. This caused `open /output: is a directory` errors because the old binary didn't support `-o` as a directory argument.

## Test plan

- [x] `make gen-prompt` rebuilds and runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)