### PR TITLE
Add make gen-prompt-up to start full monitoring stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all frontend backend build test test-e2e lint clean dev-frontend dev-backend dev-dummyprom screenshots gen-prompt
+.PHONY: all frontend backend build test test-e2e lint clean dev-frontend dev-backend dev-dummyprom screenshots gen-prompt gen-prompt-up
 
 all: build
 
@@ -39,6 +39,9 @@ gen-prompt:
 	docker compose -f docs/gen-prompt/docker-compose.yaml build gen-prompt
 	docker compose -f docs/gen-prompt/docker-compose.yaml run --rm gen-prompt
 	docker compose -f docs/gen-prompt/docker-compose.yaml down
+
+gen-prompt-up:
+	docker compose -f docs/gen-prompt/docker-compose.yaml up --build
 
 clean:
 	rm -f dashyard dummyprom

--- a/docs/gen-prompt/README.md
+++ b/docs/gen-prompt/README.md
@@ -61,7 +61,7 @@ This will:
 After generating dashboards with an LLM, place the YAML files in `output/dashboards/` and start the full stack:
 
 ```bash
-docker compose -f docs/gen-prompt/docker-compose.yaml up
+make gen-prompt-up
 ```
 
 Open http://localhost:8080 (login: admin / admin).
@@ -71,6 +71,6 @@ Open http://localhost:8080 (login: admin / admin).
 1. `make gen-prompt` — start stack → accumulate metrics → run gen-prompt → stop
 2. Feed `output/prompt.md` + `output/prompt-metrics.md` to an LLM to generate dashboard YAML files
 3. Place generated YAML files in `docs/gen-prompt/output/dashboards/`
-4. `docker compose -f docs/gen-prompt/docker-compose.yaml up` — start Dashyard + monitoring stack
+4. `make gen-prompt-up` — start Dashyard + monitoring stack
 5. Open http://localhost:8080 to verify dashboards render with real metrics
 6. If the dashboards need improvement, refine the prompt and repeat from step 1


### PR DESCRIPTION
## Summary

- Add `gen-prompt-up` Makefile target that runs `docker compose -f docs/gen-prompt/docker-compose.yaml up --build`

Shortcut for starting the full monitoring stack (Dashyard + Prometheus + OTel + Traefik + Redis) to preview LLM-generated dashboards at http://localhost:8080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)