### PR TITLE
Fix formatBytes showing undefined for fractional values

### DIFF
--- a/frontend/src/utils/units.ts
+++ b/frontend/src/utils/units.ts
@@ -3,7 +3,7 @@ export function formatBytes(value: number): string {
   const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
   const k = 1024;
   const i = Math.floor(Math.log(Math.abs(value)) / Math.log(k));
-  const idx = Math.min(i, units.length - 1);
+  const idx = Math.max(0, Math.min(i, units.length - 1));
   return `${(value / Math.pow(k, idx)).toFixed(idx > 0 ? 1 : 0)} ${units[idx]}`;
 }
 


### PR DESCRIPTION
## Summary

- Clamp the unit index in `formatBytes()` to a minimum of 0 with `Math.max(0, ...)`

When Chart.js generates y-axis tick values between 0 and 1 for byte-unit panels, `Math.log(value) / Math.log(1024)` produces a negative index. `units[-1]` is `undefined` in JavaScript, causing labels like `819 undefined` instead of `819 B`.

## Test plan

- [x] `cd frontend && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)