### PR TITLE
Add frontend unit tests with Vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
+      - run: npm run test
       - run: npm run build
 
   lint:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all frontend backend build test test-e2e lint clean dev-frontend dev-backend dev-dummyprom screenshots gen-prompt gen-prompt-up
+.PHONY: all frontend backend build test test-frontend test-e2e lint clean dev-frontend dev-backend dev-dummyprom screenshots gen-prompt gen-prompt-up
 
 all: build
 
@@ -12,6 +12,9 @@ build: backend
 
 test:
 	go test ./...
+
+test-frontend:
+	cd frontend && npm run test
 
 test-e2e:
 	cd frontend && npx playwright test

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,8 @@
         "@vitejs/plugin-react": "^4.3.0",
         "oxlint": "^1.42.0",
         "typescript": "^5.6.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1293,6 +1294,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1338,6 +1346,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1346,6 +1365,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1438,6 +1464,127 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -1521,6 +1668,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -1700,6 +1857,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1772,6 +1936,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -1986,6 +2170,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-table": {
@@ -2863,6 +3057,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/oxlint": {
       "version": "1.42.0",
       "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.42.0.tgz",
@@ -2920,6 +3125,13 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -3267,6 +3479,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3286,6 +3505,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -3319,6 +3552,23 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3334,6 +3584,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -3589,6 +3849,101 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
+    "test": "vitest run",
     "lint": "oxlint src/"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
     "@vitejs/plugin-react": "^4.3.0",
     "oxlint": "^1.42.0",
     "typescript": "^5.6.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/frontend/src/utils/time.test.ts
+++ b/frontend/src/utils/time.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { TIME_RANGES, DEFAULT_TIME_RANGE, computeStep, getTimeRangeParams } from './time';
+import type { AbsoluteTimeRange } from '../types';
+
+describe('TIME_RANGES', () => {
+  it('contains 9 predefined ranges', () => {
+    expect(TIME_RANGES).toHaveLength(9);
+  });
+
+  it('all have type relative', () => {
+    for (const r of TIME_RANGES) {
+      expect(r.type).toBe('relative');
+    }
+  });
+});
+
+describe('DEFAULT_TIME_RANGE', () => {
+  it('is 1 hour', () => {
+    expect(DEFAULT_TIME_RANGE.value).toBe('1h');
+    expect(DEFAULT_TIME_RANGE.duration).toBe(3600);
+  });
+});
+
+describe('computeStep', () => {
+  it('returns 15s for up to 15 minutes', () => {
+    expect(computeStep(15 * 60)).toBe('15s');
+    expect(computeStep(60)).toBe('15s');
+  });
+
+  it('returns 30s for up to 30 minutes', () => {
+    expect(computeStep(15 * 60 + 1)).toBe('30s');
+    expect(computeStep(30 * 60)).toBe('30s');
+  });
+
+  it('returns 60s for up to 1 hour', () => {
+    expect(computeStep(30 * 60 + 1)).toBe('60s');
+    expect(computeStep(60 * 60)).toBe('60s');
+  });
+
+  it('returns 120s for up to 3 hours', () => {
+    expect(computeStep(3 * 60 * 60)).toBe('120s');
+  });
+
+  it('returns 240s for up to 6 hours', () => {
+    expect(computeStep(6 * 60 * 60)).toBe('240s');
+  });
+
+  it('returns 480s for up to 12 hours', () => {
+    expect(computeStep(12 * 60 * 60)).toBe('480s');
+  });
+
+  it('returns 900s for up to 24 hours', () => {
+    expect(computeStep(24 * 60 * 60)).toBe('900s');
+  });
+
+  it('returns 3600s for up to 3 days', () => {
+    expect(computeStep(3 * 24 * 60 * 60)).toBe('3600s');
+  });
+
+  it('returns 7200s for longer durations', () => {
+    expect(computeStep(3 * 24 * 60 * 60 + 1)).toBe('7200s');
+    expect(computeStep(7 * 24 * 60 * 60)).toBe('7200s');
+  });
+});
+
+describe('getTimeRangeParams', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns absolute range params as-is', () => {
+    const range: AbsoluteTimeRange = {
+      type: 'absolute',
+      label: 'Custom',
+      start: 1000,
+      end: 2000,
+      step: '15s',
+    };
+    const params = getTimeRangeParams(range);
+    expect(params).toEqual({ start: 1000, end: 2000, step: '15s' });
+  });
+
+  it('computes start/end from relative range', () => {
+    const now = 1700000000;
+    vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
+
+    const params = getTimeRangeParams(DEFAULT_TIME_RANGE);
+    expect(params.end).toBe(now);
+    expect(params.start).toBe(now - 3600);
+    expect(params.step).toBe('60s');
+  });
+});

--- a/frontend/src/utils/units.test.ts
+++ b/frontend/src/utils/units.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes, formatPercent, formatCount, formatSeconds, formatValue, getYAxisTickCallback } from './units';
+
+describe('formatBytes', () => {
+  it('formats zero', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('formats bytes', () => {
+    expect(formatBytes(500)).toBe('500 B');
+  });
+
+  it('formats kilobytes', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('formats megabytes', () => {
+    expect(formatBytes(1048576)).toBe('1.0 MB');
+  });
+
+  it('formats gigabytes', () => {
+    expect(formatBytes(1073741824)).toBe('1.0 GB');
+  });
+
+  it('formats terabytes', () => {
+    expect(formatBytes(1099511627776)).toBe('1.0 TB');
+  });
+
+  it('handles negative values', () => {
+    expect(formatBytes(-1024)).toBe('-1.0 KB');
+  });
+});
+
+describe('formatPercent', () => {
+  it('formats with one decimal place', () => {
+    expect(formatPercent(75)).toBe('75.0%');
+    expect(formatPercent(99.9)).toBe('99.9%');
+    expect(formatPercent(0)).toBe('0.0%');
+  });
+
+  it('rounds to one decimal', () => {
+    expect(formatPercent(33.333)).toBe('33.3%');
+  });
+});
+
+describe('formatCount', () => {
+  it('formats small numbers', () => {
+    expect(formatCount(0)).toBe('0');
+    expect(formatCount(42)).toBe('42');
+  });
+
+  it('formats with thousands separators', () => {
+    expect(formatCount(1000)).toBe('1,000');
+    expect(formatCount(1234567)).toBe('1,234,567');
+  });
+
+  it('formats decimals with max 2 fraction digits', () => {
+    expect(formatCount(1.5)).toBe('1.5');
+    expect(formatCount(1.999)).toBe('2');
+  });
+});
+
+describe('formatSeconds', () => {
+  it('formats zero', () => {
+    expect(formatSeconds(0)).toBe('0s');
+  });
+
+  it('formats microseconds', () => {
+    expect(formatSeconds(0.0005)).toBe('500µs');
+  });
+
+  it('formats milliseconds', () => {
+    expect(formatSeconds(0.2)).toBe('200.0ms');
+    expect(formatSeconds(0.999)).toBe('999.0ms');
+  });
+
+  it('formats seconds', () => {
+    expect(formatSeconds(1)).toBe('1.00s');
+    expect(formatSeconds(30.5)).toBe('30.50s');
+  });
+
+  it('formats minutes', () => {
+    expect(formatSeconds(120)).toBe('2.0m');
+    expect(formatSeconds(90)).toBe('1.5m');
+  });
+
+  it('formats hours', () => {
+    expect(formatSeconds(3600)).toBe('1.0h');
+    expect(formatSeconds(7200)).toBe('2.0h');
+  });
+
+  it('handles negative values', () => {
+    expect(formatSeconds(-0.2)).toBe('-200.0ms');
+    expect(formatSeconds(-60)).toBe('-1.0m');
+  });
+});
+
+describe('formatValue', () => {
+  it('dispatches to formatBytes', () => {
+    expect(formatValue(1024, 'bytes')).toBe('1.0 KB');
+  });
+
+  it('dispatches to formatPercent', () => {
+    expect(formatValue(50, 'percent')).toBe('50.0%');
+  });
+
+  it('dispatches to formatSeconds', () => {
+    expect(formatValue(0.5, 'seconds')).toBe('500.0ms');
+  });
+
+  it('dispatches to formatCount', () => {
+    expect(formatValue(1000, 'count')).toBe('1,000');
+  });
+
+  it('defaults to formatCount when unit is undefined', () => {
+    expect(formatValue(1000)).toBe('1,000');
+  });
+});
+
+describe('getYAxisTickCallback', () => {
+  it('returns a callback that formats numbers', () => {
+    const cb = getYAxisTickCallback('percent');
+    expect(cb(50)).toBe('50.0%');
+  });
+
+  it('handles string values', () => {
+    const cb = getYAxisTickCallback('bytes');
+    expect(cb('1024')).toBe('1.0 KB');
+  });
+});

--- a/frontend/src/utils/variables.test.ts
+++ b/frontend/src/utils/variables.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { parseLabelValuesQuery, substituteVariables } from './variables';
+
+describe('parseLabelValuesQuery', () => {
+  it('parses a standard query', () => {
+    const result = parseLabelValuesQuery('label_values(up, instance)');
+    expect(result).toEqual({ metric: 'up', label: 'instance' });
+  });
+
+  it('handles extra whitespace', () => {
+    const result = parseLabelValuesQuery('label_values(  up  ,  instance  )');
+    expect(result).toEqual({ metric: 'up', label: 'instance' });
+  });
+
+  it('handles metric with braces', () => {
+    const result = parseLabelValuesQuery('label_values(node_cpu_seconds_total{mode="idle"}, cpu)');
+    expect(result).toEqual({ metric: 'node_cpu_seconds_total{mode="idle"}', label: 'cpu' });
+  });
+
+  it('returns null for invalid format', () => {
+    expect(parseLabelValuesQuery('not a query')).toBeNull();
+    expect(parseLabelValuesQuery('label_values()')).toBeNull();
+    expect(parseLabelValuesQuery('label_values(metric)')).toBeNull();
+    expect(parseLabelValuesQuery('')).toBeNull();
+  });
+});
+
+describe('substituteVariables', () => {
+  it('replaces ${var} form', () => {
+    expect(substituteVariables('rate(http_requests{job="${job}"}[5m])', { job: 'api' }))
+      .toBe('rate(http_requests{job="api"}[5m])');
+  });
+
+  it('replaces $var form', () => {
+    expect(substituteVariables('up{instance=~"$instance"}', { instance: 'localhost:9090' }))
+      .toBe('up{instance=~"localhost:9090"}');
+  });
+
+  it('does not replace $var when followed by word characters', () => {
+    expect(substituteVariables('$device_total', { device: 'eth0' }))
+      .toBe('$device_total');
+  });
+
+  it('replaces multiple variables', () => {
+    const result = substituteVariables('up{job="$job", instance="$instance"}', {
+      job: 'api',
+      instance: 'localhost',
+    });
+    expect(result).toBe('up{job="api", instance="localhost"}');
+  });
+
+  it('handles longer variable names first to avoid prefix collisions', () => {
+    const result = substituteVariables('$dev $device', {
+      dev: 'A',
+      device: 'B',
+    });
+    expect(result).toBe('A B');
+  });
+
+  it('returns template unchanged when no variables', () => {
+    expect(substituteVariables('up{job="api"}', {})).toBe('up{job="api"}');
+  });
+
+  it('returns empty/undefined template as-is', () => {
+    expect(substituteVariables('', { job: 'api' })).toBe('');
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    exclude: ['e2e/**', 'node_modules/**'],
+  },
+});


### PR DESCRIPTION
## Summary
- Add Vitest as frontend unit testing framework alongside existing Playwright E2E tests
- Add 51 unit tests covering all three utility modules:
  - **units.ts** (26 tests): `formatBytes`, `formatPercent`, `formatCount`, `formatSeconds`, `formatValue`, `getYAxisTickCallback`
  - **time.ts** (14 tests): `TIME_RANGES`, `DEFAULT_TIME_RANGE`, `computeStep`, `getTimeRangeParams`
  - **variables.ts** (11 tests): `parseLabelValuesQuery`, `substituteVariables`
- Add `vitest.config.ts` that excludes the `e2e/` directory
- Add `npm run test` script and `make test-frontend` target
- Add unit test step to CI workflow (runs before build in the frontend job)

Fixes #87

## Test plan
- [ ] `cd frontend && npm run test` — all 51 tests pass
- [ ] `cd frontend && npm run build` — TypeScript + Vite build still works
- [ ] `make test-frontend` — Makefile target works
- [ ] CI frontend job runs unit tests before build

🤖 Generated with [Claude Code](https://claude.com/claude-code)