### PR TITLE
Run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,12 @@ RUN CGO_ENABLED=0 go build -o dashyard .
 
 ## Stage 3: Runtime
 FROM alpine:3.20
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates && \
+    addgroup -S dashyard && adduser -S dashyard -G dashyard
 WORKDIR /app
 COPY --from=backend-builder /app/dashyard .
+USER dashyard
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://localhost:8080/ready || exit 1
 ENTRYPOINT ["/app/dashyard"]
 CMD ["serve", "--config", "/etc/dashyard/config.yaml"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,10 @@
 FROM alpine:3.20
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates && \
+    addgroup -S dashyard && adduser -S dashyard -G dashyard
 WORKDIR /app
 COPY dashyard /app/dashyard
+USER dashyard
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://localhost:8080/ready || exit 1
 ENTRYPOINT ["/app/dashyard"]
 CMD ["serve", "--config", "/etc/dashyard/config.yaml"]


### PR DESCRIPTION
## Summary
- Add `dashyard` system user/group in both `Dockerfile` and `Dockerfile.goreleaser`
- Switch to `USER dashyard` before `ENTRYPOINT` so the container runs as non-root
- Add `HEALTHCHECK` instruction using `GET /ready` (from #85)

Fixes #86

## Test plan
- [ ] `docker build -t dashyard .` succeeds
- [ ] `docker inspect dashyard --format '{{.Config.User}}'` returns `dashyard`
- [ ] `docker inspect dashyard --format '{{.Config.Healthcheck}}'` shows the wget check
- [ ] Container starts and serves dashboards normally with mounted config/dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)