### PR TITLE
Add Dependabot for dependency scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly scanning for:
  - **Go modules** — `go.mod` in project root
  - **npm** — `package.json` in `/frontend`
  - **GitHub Actions** — workflow action versions in `.github/workflows/`

Fixes #88

## Test plan
- [ ] Dependabot config is valid YAML and follows the [v2 schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- [ ] After merge, verify Dependabot starts opening PRs on the Insights > Dependency graph > Dependabot tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)