### PR TITLE
Run validate on example config and dashboards in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
         run: go test ./...
       - name: Build binary
         run: go build -o dashyard .
+      - name: Validate config
+        run: ./dashyard validate config examples/config.yaml
+      - name: Validate dashboards
+        run: ./dashyard validate dashboards examples/dashboards
 
   e2e:
     name: E2E Tests


### PR DESCRIPTION
## Summary

- Add `validate config` and `validate dashboards` steps to the CI backend job
- Runs against `examples/config.yaml` and `examples/dashboards` after building the binary
- Catches broken example configs/dashboards before merge

## Test plan

- [ ] CI backend job passes with the new validate steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)