### PR TITLE
Add dummyapp and reorganize examples directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ make dev-dummygithub             # Fake GitHub OAuth server on :5555
 - `examples/kitchensink/` -- Kitchen-sink demo configs and dashboards
 - `examples/real-world/` -- Real monitoring stack with gen-prompt workflow
 - `cmd/dummyprom/` -- Fake Prometheus that generates synthetic metrics
+- `cmd/dummyapp/` -- Fake web app exposing custom Prometheus metrics (HTTP RED, business KPIs)
 - `cmd/dummygithub/` -- Fake GitHub OAuth server for local development
 
 ## Key Patterns

--- a/Dockerfile.dummyapp
+++ b/Dockerfile.dummyapp
@@ -1,0 +1,11 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o dummyapp ./cmd/dummyapp
+
+FROM alpine:3.20
+COPY --from=builder /app/dummyapp /usr/local/bin/dummyapp
+EXPOSE 3000
+ENTRYPOINT ["/usr/local/bin/dummyapp"]

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ screenshots:
 	docker compose -f docker-compose.screenshots.yaml down
 
 gen-prompt:
-	docker compose -f examples/real-world/docker-compose.yaml up -d prometheus otelcol traefik redis whoami traffic-gen
+	docker compose -f examples/real-world/docker-compose.yaml up -d prometheus otelcol traefik redis whoami dummyapp traffic-gen
 	@echo "Waiting 60s for metrics to accumulate..."
 	@sleep 60
 	docker compose -f examples/real-world/docker-compose.yaml build gen-prompt

--- a/cmd/dummyapp/main.go
+++ b/cmd/dummyapp/main.go
@@ -1,0 +1,303 @@
+// dummyapp is a fake web application that exposes Prometheus metrics
+// simulating a real service with HTTP RED metrics, business KPIs,
+// job queues, DB connections, and cache statistics.
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	httpRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "myapp_http_requests_total",
+		Help: "Total HTTP requests.",
+	}, []string{"method", "path", "status"})
+
+	httpRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "myapp_http_request_duration_seconds",
+		Help:    "HTTP request latency.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"method", "path"})
+
+	httpRequestsInFlight = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "myapp_http_requests_in_flight",
+		Help: "Number of HTTP requests currently in flight.",
+	})
+
+	ordersCreatedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "myapp_orders_created_total",
+		Help: "Total orders created.",
+	}, []string{"status"})
+
+	revenueTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "myapp_revenue_total",
+		Help: "Total revenue.",
+	}, []string{"currency"})
+
+	usersActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "myapp_users_active",
+		Help: "Number of currently active users.",
+	})
+
+	usersRegisteredTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "myapp_users_registered_total",
+		Help: "Total user registrations.",
+	})
+
+	jobsProcessedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "myapp_jobs_processed_total",
+		Help: "Total background jobs processed.",
+	}, []string{"queue", "status"})
+
+	jobsDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "myapp_jobs_duration_seconds",
+		Help:    "Background job processing time.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"queue"})
+
+	jobsQueueDepth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "myapp_jobs_queue_depth",
+		Help: "Number of pending jobs in queue.",
+	}, []string{"queue"})
+
+	dbConnectionsActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "myapp_db_connections_active",
+		Help: "Number of active DB connections.",
+	})
+
+	dbConnectionsIdle = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "myapp_db_connections_idle",
+		Help: "Number of idle DB connections.",
+	})
+
+	dbQueryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "myapp_db_query_duration_seconds",
+		Help:    "DB query latency.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"operation"})
+
+	cacheHitsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "myapp_cache_hits_total",
+		Help: "Total cache hits.",
+	})
+
+	cacheMissesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "myapp_cache_misses_total",
+		Help: "Total cache misses.",
+	})
+
+	errorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "myapp_errors_total",
+		Help: "Total errors by type.",
+	}, []string{"type"})
+)
+
+func init() {
+	prometheus.MustRegister(
+		httpRequestsTotal,
+		httpRequestDuration,
+		httpRequestsInFlight,
+		ordersCreatedTotal,
+		revenueTotal,
+		usersActive,
+		usersRegisteredTotal,
+		jobsProcessedTotal,
+		jobsDuration,
+		jobsQueueDepth,
+		dbConnectionsActive,
+		dbConnectionsIdle,
+		dbQueryDuration,
+		cacheHitsTotal,
+		cacheMissesTotal,
+		errorsTotal,
+	)
+}
+
+func main() {
+	port := "3000"
+	if p := os.Getenv("PORT"); p != "" {
+		port = p
+	}
+
+	// Start background simulation goroutines.
+	go simulateOrders()
+	go simulateUsers()
+	go simulateJobs()
+	go simulateDBPool()
+	go simulateCache()
+	go simulateErrors()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", instrumentHandler("GET", "/", handleIndex))
+	mux.HandleFunc("/api/users", instrumentHandler("GET", "/api/users", handleAPIUsers))
+	mux.HandleFunc("/api/orders", instrumentHandler("POST", "/api/orders", handleAPIOrders))
+	mux.HandleFunc("/api/search", instrumentHandler("GET", "/api/search", handleAPISearch))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintln(w, "OK")
+	})
+	mux.Handle("/metrics", promhttp.Handler())
+
+	slog.Info("dummyapp starting", "port", port)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
+		slog.Error("server error", "error", err)
+		os.Exit(1)
+	}
+}
+
+// instrumentHandler wraps a handler to record HTTP metrics.
+func instrumentHandler(method, path string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		httpRequestsInFlight.Inc()
+		defer httpRequestsInFlight.Dec()
+
+		start := time.Now()
+		next(w, r)
+		duration := time.Since(start).Seconds()
+
+		status := "200"
+		// Simulate occasional errors.
+		if rand.Float64() < 0.02 {
+			status = "500"
+		}
+
+		httpRequestsTotal.WithLabelValues(method, path, status).Inc()
+		httpRequestDuration.WithLabelValues(method, path).Observe(duration)
+	}
+}
+
+func handleIndex(w http.ResponseWriter, _ *http.Request) {
+	time.Sleep(time.Duration(5+rand.IntN(15)) * time.Millisecond)
+	_, _ = fmt.Fprintln(w, "OK")
+}
+
+func handleAPIUsers(w http.ResponseWriter, _ *http.Request) {
+	time.Sleep(time.Duration(10+rand.IntN(40)) * time.Millisecond)
+	// Simulate DB query.
+	dbQueryDuration.WithLabelValues("select").Observe(0.005 + rand.Float64()*0.02)
+	_, _ = fmt.Fprintln(w, `{"users":[]}`)
+}
+
+func handleAPIOrders(w http.ResponseWriter, _ *http.Request) {
+	time.Sleep(time.Duration(20+rand.IntN(80)) * time.Millisecond)
+	// Simulate DB write.
+	dbQueryDuration.WithLabelValues("insert").Observe(0.01 + rand.Float64()*0.03)
+	_, _ = fmt.Fprintln(w, `{"order_id":"123"}`)
+}
+
+func handleAPISearch(w http.ResponseWriter, _ *http.Request) {
+	time.Sleep(time.Duration(30+rand.IntN(120)) * time.Millisecond)
+	// Simulate DB query.
+	dbQueryDuration.WithLabelValues("select").Observe(0.02 + rand.Float64()*0.05)
+	_, _ = fmt.Fprintln(w, `{"results":[]}`)
+}
+
+// simulateOrders generates order and revenue metrics.
+func simulateOrders() {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		// 70% completed, 20% failed, 10% cancelled
+		r := rand.Float64()
+		switch {
+		case r < 0.7:
+			ordersCreatedTotal.WithLabelValues("completed").Inc()
+			revenueTotal.WithLabelValues("USD").Add(10 + rand.Float64()*90)
+		case r < 0.9:
+			ordersCreatedTotal.WithLabelValues("failed").Inc()
+		default:
+			ordersCreatedTotal.WithLabelValues("cancelled").Inc()
+		}
+	}
+}
+
+// simulateUsers generates user activity metrics.
+func simulateUsers() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		// Active users fluctuate with a sine wave pattern.
+		t := float64(time.Now().Unix())
+		active := 200 + 80*math.Sin(t/300) + float64(rand.IntN(30))
+		usersActive.Set(active)
+
+		// Occasional registrations.
+		if rand.Float64() < 0.3 {
+			usersRegisteredTotal.Inc()
+		}
+	}
+}
+
+// simulateJobs generates background job metrics.
+func simulateJobs() {
+	queues := []string{"email", "export", "cleanup"}
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		for _, q := range queues {
+			// Process 1-3 jobs per tick.
+			n := 1 + rand.IntN(3)
+			for range n {
+				duration := 0.1 + rand.Float64()*2.0
+				jobsDuration.WithLabelValues(q).Observe(duration)
+
+				if rand.Float64() < 0.9 {
+					jobsProcessedTotal.WithLabelValues(q, "success").Inc()
+				} else {
+					jobsProcessedTotal.WithLabelValues(q, "failure").Inc()
+				}
+			}
+			// Queue depth fluctuates.
+			depth := float64(rand.IntN(20))
+			jobsQueueDepth.WithLabelValues(q).Set(depth)
+		}
+	}
+}
+
+// simulateDBPool generates DB connection pool metrics.
+func simulateDBPool() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	maxConns := 20.0
+	for range ticker.C {
+		active := 5 + float64(rand.IntN(10))
+		if active > maxConns {
+			active = maxConns
+		}
+		idle := maxConns - active
+		dbConnectionsActive.Set(active)
+		dbConnectionsIdle.Set(idle)
+	}
+}
+
+// simulateCache generates cache hit/miss metrics.
+func simulateCache() {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		hits := 5 + rand.IntN(15)
+		misses := 1 + rand.IntN(5)
+		cacheHitsTotal.Add(float64(hits))
+		cacheMissesTotal.Add(float64(misses))
+	}
+}
+
+// simulateErrors generates error metrics.
+func simulateErrors() {
+	types := []string{"timeout", "connection_refused", "internal", "validation"}
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		// Pick a random error type.
+		t := types[rand.IntN(len(types))]
+		errorsTotal.WithLabelValues(t).Inc()
+	}
+}

--- a/examples/real-world/config.yaml
+++ b/examples/real-world/config.yaml
@@ -11,4 +11,4 @@ prometheus:
 
 users:
   - id: "admin"
-    password_hash: "$6$D/BkIQYiHD.cKL4A$pbAApV8cWXOv3hTyITrHNmlWe3FyfIJyM2CVFuJxbmXwDZPIVbcXKJbM2dxmJqG/ZJZBtrt8e9bVxt0d7rQKK."
+    password_hash: "$6$Je8bLj2qQZHNsrP3$HVmNqT10MBiEhQ0Naa9DuSbdA5qsUBYAGzW8njdAR2JIzgZ5SzSoSRYP58WG1rU55Kff7fnxs0yuoPn6izgtm."

--- a/examples/real-world/docker-compose.yaml
+++ b/examples/real-world/docker-compose.yaml
@@ -41,6 +41,19 @@ services:
   whoami:
     image: traefik/whoami
 
+  # --- Dummy application with custom Prometheus metrics ---
+  dummyapp:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.dummyapp
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/healthz || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   # --- Redis ---
   redis:
     image: redis:7-alpine
@@ -60,12 +73,17 @@ services:
           wget -q -O /dev/null http://traefik:80/ 2>/dev/null
           wget -q -O /dev/null http://traefik:80/api 2>/dev/null
           wget -q -O /dev/null http://traefik:80/health 2>/dev/null
+          wget -q -O /dev/null http://dummyapp:3000/ 2>/dev/null
+          wget -q -O /dev/null http://dummyapp:3000/api/users 2>/dev/null
+          wget -q -O /dev/null --post-data='' http://dummyapp:3000/api/orders 2>/dev/null
+          wget -q -O /dev/null http://dummyapp:3000/api/search 2>/dev/null
           redis-cli -h redis PING >/dev/null 2>&1 || true
           sleep 0.5
         done
     depends_on:
       - traefik
       - redis
+      - dummyapp
 
   # --- Dashyard dashboard viewer ---
   dashyard:

--- a/examples/real-world/output/dashboards/app/business.yaml
+++ b/examples/real-world/output/dashboards/app/business.yaml
@@ -1,0 +1,74 @@
+title: "App Business KPIs"
+rows:
+  - title: "Overview"
+    panels:
+      - title: "About"
+        type: markdown
+        content: |
+          Business-level key performance indicators: active users, registrations,
+          order volume, revenue, and application error breakdown.
+
+  - title: "Users"
+    panels:
+      - title: "Active Users"
+        type: graph
+        query: 'myapp_users_active'
+        unit: count
+        y_min: 0
+      - title: "Registration Rate"
+        type: graph
+        query: 'rate(myapp_users_registered_total[5m])'
+        unit: count
+        chart_type: bar
+        y_min: 0
+
+  - title: "Orders"
+    panels:
+      - title: "Order Rate by Status"
+        type: graph
+        query: 'sum by (status) (rate(myapp_orders_created_total[5m]))'
+        unit: count
+        chart_type: bar
+        legend: "{status}"
+        y_min: 0
+      - title: "Failed Order Rate"
+        type: graph
+        query: 'rate(myapp_orders_created_total{status="failed"}[5m])'
+        unit: count
+        chart_type: bar
+        y_min: 0
+        thresholds:
+          - value: 1
+            color: "#f59e0b"
+            label: "Warning"
+
+  - title: "Revenue"
+    panels:
+      - title: "Revenue Rate"
+        type: graph
+        query: 'rate(myapp_revenue_total[5m])'
+        unit: count
+        chart_type: bar
+        y_min: 0
+
+  - title: "Errors"
+    panels:
+      - title: "Error Rate by Type"
+        type: graph
+        query: 'sum by (type) (rate(myapp_errors_total[5m]))'
+        unit: count
+        chart_type: bar
+        legend: "{type}"
+        y_min: 0
+        thresholds:
+          - value: 1
+            color: "#f59e0b"
+            label: "Warning"
+      - title: "Error Rate (Stacked)"
+        type: graph
+        query: 'sum by (type) (rate(myapp_errors_total[5m]))'
+        unit: count
+        chart_type: area
+        stacked: true
+        legend: "{type}"
+        y_min: 0

--- a/examples/real-world/output/dashboards/app/database.yaml
+++ b/examples/real-world/output/dashboards/app/database.yaml
@@ -1,0 +1,86 @@
+title: "App Database & Cache"
+rows:
+  - title: "Overview"
+    panels:
+      - title: "About"
+        type: markdown
+        content: |
+          Database connection pool, query performance, and application cache metrics.
+          DB queries are broken down by operation type (select, insert).
+
+  - title: "DB Connections"
+    panels:
+      - title: "Active Connections"
+        type: graph
+        query: 'myapp_db_connections_active'
+        unit: count
+        y_min: 0
+        thresholds:
+          - value: 80
+            color: "#f59e0b"
+            label: "Warning"
+      - title: "Idle Connections"
+        type: graph
+        query: 'myapp_db_connections_idle'
+        unit: count
+        y_min: 0
+
+  - title: "DB Query Duration"
+    panels:
+      - title: "Query Duration p99 by Operation"
+        type: graph
+        query: 'histogram_quantile(0.99, sum by (le, operation) (rate(myapp_db_query_duration_seconds_bucket[5m])))'
+        unit: seconds
+        legend: "{operation}"
+        y_min: 0
+        thresholds:
+          - value: 0.1
+            color: "#f59e0b"
+            label: "Slow"
+          - value: 1
+            color: "#ef4444"
+            label: "Very Slow"
+      - title: "Query Duration p75 by Operation"
+        type: graph
+        query: 'histogram_quantile(0.75, sum by (le, operation) (rate(myapp_db_query_duration_seconds_bucket[5m])))'
+        unit: seconds
+        legend: "{operation}"
+        y_min: 0
+      - title: "Query Rate by Operation"
+        type: graph
+        query: 'sum by (operation) (rate(myapp_db_query_duration_seconds_count[5m]))'
+        unit: count
+        chart_type: bar
+        legend: "{operation}"
+        y_min: 0
+      - title: "Avg Query Duration by Operation"
+        type: graph
+        query: 'sum by (operation) (rate(myapp_db_query_duration_seconds_sum[5m])) / (sum by (operation) (rate(myapp_db_query_duration_seconds_count[5m])) > 0)'
+        unit: seconds
+        legend: "{operation}"
+        y_min: 0
+
+  - title: "Cache"
+    panels:
+      - title: "Cache Hit Rate"
+        type: graph
+        query: 'rate(myapp_cache_hits_total[5m]) / (rate(myapp_cache_hits_total[5m]) + rate(myapp_cache_misses_total[5m]) > 0) * 100'
+        unit: percent
+        y_min: 0
+        y_max: 100
+        thresholds:
+          - value: 80
+            color: "#f59e0b"
+            label: "Low Hit Rate"
+      - title: "Cache Hits Rate"
+        type: graph
+        query: 'rate(myapp_cache_hits_total[5m])'
+        unit: count
+        chart_type: bar
+        y_min: 0
+      - title: "Cache Misses Rate"
+        type: graph
+        query: 'rate(myapp_cache_misses_total[5m])'
+        unit: count
+        chart_type: bar
+        y_min: 0

--- a/examples/real-world/output/dashboards/app/http.yaml
+++ b/examples/real-world/output/dashboards/app/http.yaml
@@ -1,0 +1,92 @@
+title: "App HTTP"
+variables:
+  - name: path
+    label: "Path"
+    query: "label_values(myapp_http_requests_total, path)"
+rows:
+  - title: "Overview"
+    panels:
+      - title: "About"
+        type: markdown
+        content: |
+          HTTP service metrics from the application using the RED method
+          (Rate, Errors, Duration). Metrics are broken down by path, method, and status code.
+
+  - title: "Rate"
+    panels:
+      - title: "Request Rate by Path"
+        type: graph
+        query: 'sum by (path) (rate(myapp_http_requests_total[5m]))'
+        unit: count
+        chart_type: bar
+        legend: "{path}"
+        y_min: 0
+      - title: "Request Rate by Method"
+        type: graph
+        query: 'sum by (method) (rate(myapp_http_requests_total[5m]))'
+        unit: count
+        chart_type: bar
+        legend: "{method}"
+        y_min: 0
+      - title: "Requests In Flight"
+        type: graph
+        query: 'myapp_http_requests_in_flight'
+        unit: count
+        y_min: 0
+
+  - title: "Errors"
+    panels:
+      - title: "Error Rate (5xx)"
+        type: graph
+        query: 'sum by (path) (rate(myapp_http_requests_total{status=~"5.."}[5m]))'
+        unit: count
+        chart_type: bar
+        legend: "{path}"
+        y_min: 0
+        thresholds:
+          - value: 1
+            color: "#f59e0b"
+            label: "Warning"
+          - value: 10
+            color: "#ef4444"
+            label: "Critical"
+      - title: "Error Ratio by Path"
+        type: graph
+        query: 'sum by (path) (rate(myapp_http_requests_total{status=~"5.."}[5m])) / (sum by (path) (rate(myapp_http_requests_total[5m])) > 0) * 100'
+        unit: percent
+        legend: "{path}"
+        y_min: 0
+        y_max: 100
+        thresholds:
+          - value: 5
+            color: "#f59e0b"
+            label: "Warning"
+          - value: 25
+            color: "#ef4444"
+            label: "Critical"
+
+  - title: "Duration - $path"
+    repeat: path
+    panels:
+      - title: "Request Duration p99 ($path)"
+        type: graph
+        query: 'histogram_quantile(0.99, sum by (le) (rate(myapp_http_request_duration_seconds_bucket{path="$path"}[5m])))'
+        unit: seconds
+        y_min: 0
+        thresholds:
+          - value: 1
+            color: "#f59e0b"
+            label: "Slow"
+          - value: 5
+            color: "#ef4444"
+            label: "Very Slow"
+      - title: "Request Duration p75 ($path)"
+        type: graph
+        query: 'histogram_quantile(0.75, sum by (le) (rate(myapp_http_request_duration_seconds_bucket{path="$path"}[5m])))'
+        unit: seconds
+        y_min: 0
+      - title: "Avg Request Duration ($path)"
+        type: graph
+        query: 'rate(myapp_http_request_duration_seconds_sum{path="$path"}[5m]) / (rate(myapp_http_request_duration_seconds_count{path="$path"}[5m]) > 0)'
+        unit: seconds
+        y_min: 0

--- a/examples/real-world/output/dashboards/app/jobs.yaml
+++ b/examples/real-world/output/dashboards/app/jobs.yaml
@@ -1,0 +1,83 @@
+title: "App Background Jobs"
+variables:
+  - name: queue
+    label: "Queue"
+    query: "label_values(myapp_jobs_queue_depth, queue)"
+rows:
+  - title: "Overview"
+    panels:
+      - title: "About"
+        type: markdown
+        content: |
+          Background job processing metrics. Jobs are organized by queue
+          (cleanup, email, export) and tracked by throughput, failures, queue depth,
+          and processing duration.
+
+  - title: "Queue Depth"
+    panels:
+      - title: "Pending Jobs by Queue"
+        type: graph
+        query: 'myapp_jobs_queue_depth'
+        unit: count
+        legend: "{queue}"
+        y_min: 0
+        thresholds:
+          - value: 100
+            color: "#f59e0b"
+            label: "Backlog Warning"
+          - value: 1000
+            color: "#ef4444"
+            label: "Backlog Critical"
+
+  - title: "Throughput - $queue"
+    repeat: queue
+    panels:
+      - title: "Processed Rate ($queue)"
+        type: graph
+        query: 'sum by (status) (rate(myapp_jobs_processed_total{queue="$queue"}[5m]))'
+        unit: count
+        chart_type: bar
+        legend: "{status}"
+        y_min: 0
+      - title: "Failure Rate ($queue)"
+        type: graph
+        query: 'rate(myapp_jobs_processed_total{queue="$queue", status="failure"}[5m])'
+        unit: count
+        chart_type: bar
+        y_min: 0
+        thresholds:
+          - value: 1
+            color: "#f59e0b"
+            label: "Failures"
+      - title: "Failure Ratio ($queue)"
+        type: graph
+        query: 'rate(myapp_jobs_processed_total{queue="$queue", status="failure"}[5m]) / (sum(rate(myapp_jobs_processed_total{queue="$queue"}[5m])) > 0) * 100'
+        unit: percent
+        y_min: 0
+        y_max: 100
+        thresholds:
+          - value: 5
+            color: "#f59e0b"
+            label: "Warning"
+          - value: 25
+            color: "#ef4444"
+            label: "Critical"
+
+  - title: "Duration - $queue"
+    repeat: queue
+    panels:
+      - title: "Job Duration p99 ($queue)"
+        type: graph
+        query: 'histogram_quantile(0.99, sum by (le) (rate(myapp_jobs_duration_seconds_bucket{queue="$queue"}[5m])))'
+        unit: seconds
+        y_min: 0
+      - title: "Job Duration p75 ($queue)"
+        type: graph
+        query: 'histogram_quantile(0.75, sum by (le) (rate(myapp_jobs_duration_seconds_bucket{queue="$queue"}[5m])))'
+        unit: seconds
+        y_min: 0
+      - title: "Avg Job Duration ($queue)"
+        type: graph
+        query: 'rate(myapp_jobs_duration_seconds_sum{queue="$queue"}[5m]) / (rate(myapp_jobs_duration_seconds_count{queue="$queue"}[5m]) > 0)'
+        unit: seconds
+        y_min: 0

--- a/examples/real-world/output/dashboards/go-runtime.yaml
+++ b/examples/real-world/output/dashboards/go-runtime.yaml
@@ -34,6 +34,29 @@ rows:
           - value: 1000
             color: "#f59e0b"
             label: "Warning"
+      - title: "Max File Descriptors"
+        type: graph
+        query: 'process_max_fds'
+        unit: count
+        y_min: 0
+      - title: "Virtual Memory Limit"
+        type: graph
+        query: 'process_virtual_memory_max_bytes'
+        unit: bytes
+        y_min: 0
+
+  - title: "Process Network"
+    panels:
+      - title: "Network Receive Rate"
+        type: graph
+        query: 'rate(process_network_receive_bytes_total[5m])'
+        unit: bytes
+        y_min: 0
+      - title: "Network Transmit Rate"
+        type: graph
+        query: 'rate(process_network_transmit_bytes_total[5m])'
+        unit: bytes
+        y_min: 0
 
   - title: "Goroutines & Threads"
     panels:
@@ -46,6 +69,24 @@ rows:
         type: graph
         query: 'go_threads'
         unit: count
+        y_min: 0
+      - title: "GOMAXPROCS"
+        type: graph
+        query: 'go_sched_gomaxprocs_threads'
+        unit: count
+        y_min: 0
+
+  - title: "GC Config"
+    panels:
+      - title: "GOGC Percent"
+        type: graph
+        query: 'go_gc_gogc_percent'
+        unit: count
+        y_min: 0
+      - title: "Memory Limit (GOMEMLIMIT)"
+        type: graph
+        query: 'go_gc_gomemlimit_bytes'
+        unit: bytes
         y_min: 0
 
   - title: "GC"
@@ -190,6 +231,21 @@ rows:
         type: graph
         query: 'go_memstats_stack_sys_bytes'
         unit: bytes
+        y_min: 0
+
+  - title: "Prometheus Scrape Handler"
+    panels:
+      - title: "Scrape Handler Request Rate"
+        type: graph
+        query: 'sum by (code) (rate(promhttp_metric_handler_requests_total[5m]))'
+        unit: count
+        chart_type: bar
+        legend: "{code}"
+        y_min: 0
+      - title: "Scrape Handler In Flight"
+        type: graph
+        query: 'promhttp_metric_handler_requests_in_flight'
+        unit: count
         y_min: 0
 
   - title: "Scrape"

--- a/examples/real-world/output/prompt-metrics.md
+++ b/examples/real-world/output/prompt-metrics.md
@@ -2,108 +2,199 @@
 
 ## go_gc
 
-- `go_gc_duration_seconds` (summary) — A summary of the pause duration of garbage collection cycles.
-  Labels: instance (1 values), job (1 values), quantile (5 values)
+- `go_gc_duration_seconds` (summary) — A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.
+  Labels: instance (2 values), job (2 values), quantile (5 values)
 - `go_gc_duration_seconds_count`
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 - `go_gc_duration_seconds_sum`
+  Labels: instance (2 values), job (2 values)
+- `go_gc_gogc_percent` (gauge) — Heap size target percentage configured by the user, otherwise 100. This value is set by the GOGC environment variable, and the runtime/debug.SetGCPercent function. Sourced from /gc/gogc:percent.
+  Labels: instance (1 values), job (1 values)
+- `go_gc_gomemlimit_bytes` (gauge) — Go runtime memory limit configured by the user, otherwise math.MaxInt64. This value is set by the GOMEMLIMIT environment variable, and the runtime/debug.SetMemoryLimit function. Sourced from /gc/gomemlimit:bytes.
   Labels: instance (1 values), job (1 values)
 
 ## go_goroutines
 
 - `go_goroutines` (gauge) — Number of goroutines that currently exist.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 
 ## go_info
 
 - `go_info` (gauge) — Information about the Go environment.
-  Labels: instance (1 values), job (1 values), version (1 values)
+  Labels: instance (2 values), job (2 values), version (2 values)
 
 ## go_memstats
 
-- `go_memstats_alloc_bytes` (gauge) — Number of bytes allocated and still in use.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_alloc_bytes_total` (counter) — Total number of bytes allocated, even if freed.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_buck_hash_sys_bytes` (gauge) — Number of bytes used by the profiling bucket hash table.
-  Labels: instance (1 values), job (1 values)
+- `go_memstats_alloc_bytes` (gauge) — Number of bytes allocated in heap and currently in use. Equals to /memory/classes/heap/objects:bytes.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_alloc_bytes_total` (counter) — Total number of bytes allocated in heap until now, even if released already. Equals to /gc/heap/allocs:bytes.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_buck_hash_sys_bytes` (gauge) — Number of bytes used by the profiling bucket hash table. Equals to /memory/classes/profiling/buckets:bytes.
+  Labels: instance (2 values), job (2 values)
 - `go_memstats_frees_total` (counter) — Total number of frees.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_gc_sys_bytes` (gauge) — Number of bytes used for garbage collection system metadata.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_gc_sys_bytes` (gauge) — Number of bytes used for garbage collection system metadata. Equals to /memory/classes/metadata/other:bytes.
+  Labels: instance (2 values), job (2 values)
 - `go_memstats_heap_alloc_bytes` (gauge) — Number of heap bytes allocated and still in use.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_heap_idle_bytes` (gauge) — Number of heap bytes waiting to be used.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_heap_inuse_bytes` (gauge) — Number of heap bytes that are in use.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_heap_objects` (gauge) — Number of allocated objects.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_heap_released_bytes` (gauge) — Number of heap bytes released to OS.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_heap_idle_bytes` (gauge) — Number of heap bytes waiting to be used. Equals to /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_heap_inuse_bytes` (gauge) — Number of heap bytes that are in use. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_heap_objects` (gauge) — Number of currently allocated objects. Equals to /gc/heap/objects:objects.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_heap_released_bytes` (gauge) — Number of heap bytes released to OS. Equals to /memory/classes/heap/released:bytes.
+  Labels: instance (2 values), job (2 values)
 - `go_memstats_heap_sys_bytes` (gauge) — Number of heap bytes obtained from system.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 - `go_memstats_last_gc_time_seconds` (gauge) — Number of seconds since 1970 of last garbage collection.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 - `go_memstats_lookups_total` (counter) — Total number of pointer lookups.
   Labels: instance (1 values), job (1 values)
-- `go_memstats_mallocs_total` (counter) — Total number of mallocs.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_mcache_inuse_bytes` (gauge) — Number of bytes in use by mcache structures.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_mcache_sys_bytes` (gauge) — Number of bytes used for mcache structures obtained from system.
-  Labels: instance (1 values), job (1 values)
+- `go_memstats_mallocs_total` (counter) — Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge. Equals to /gc/heap/allocs:objects + /gc/heap/tiny/allocs:objects.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_mcache_inuse_bytes` (gauge) — Number of bytes in use by mcache structures. Equals to /memory/classes/metadata/mcache/inuse:bytes.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_mcache_sys_bytes` (gauge) — Number of bytes used for mcache structures obtained from system. Equals to /memory/classes/metadata/mcache/inuse:bytes + /memory/classes/metadata/mcache/free:bytes.
+  Labels: instance (2 values), job (2 values)
 - `go_memstats_mspan_inuse_bytes` (gauge) — Number of bytes in use by mspan structures.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_mspan_sys_bytes` (gauge) — Number of bytes used for mspan structures obtained from system.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_next_gc_bytes` (gauge) — Number of heap bytes when next garbage collection will take place.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_other_sys_bytes` (gauge) — Number of bytes used for other system allocations.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_stack_inuse_bytes` (gauge) — Number of bytes in use by the stack allocator.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_mspan_sys_bytes` (gauge) — Number of bytes used for mspan structures obtained from system. Equals to /memory/classes/metadata/mspan/inuse:bytes + /memory/classes/metadata/mspan/free:bytes.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_next_gc_bytes` (gauge) — Number of heap bytes when next garbage collection will take place. Equals to /gc/heap/goal:bytes.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_other_sys_bytes` (gauge) — Number of bytes used for other system allocations. Equals to /memory/classes/other:bytes.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_stack_inuse_bytes` (gauge) — Number of bytes obtained from system for stack allocator in non-CGO environments. Equals to /memory/classes/heap/stacks:bytes.
+  Labels: instance (2 values), job (2 values)
 - `go_memstats_stack_sys_bytes` (gauge) — Number of bytes obtained from system for stack allocator.
-  Labels: instance (1 values), job (1 values)
-- `go_memstats_sys_bytes` (gauge) — Number of bytes obtained from system.
+  Labels: instance (2 values), job (2 values)
+- `go_memstats_sys_bytes` (gauge) — Number of bytes obtained from system. Equals to /memory/classes/total:byte.
+  Labels: instance (2 values), job (2 values)
+
+## go_sched
+
+- `go_sched_gomaxprocs_threads` (gauge) — The current runtime.GOMAXPROCS setting, or the number of operating system threads that can execute user-level Go code simultaneously. Sourced from /sched/gomaxprocs:threads.
   Labels: instance (1 values), job (1 values)
 
 ## go_threads
 
 - `go_threads` (gauge) — Number of OS threads created.
+  Labels: instance (2 values), job (2 values)
+
+## myapp_cache
+
+- `myapp_cache_hits_total` (counter) — Total cache hits.
+  Labels: instance (1 values), job (1 values)
+- `myapp_cache_misses_total` (counter) — Total cache misses.
+  Labels: instance (1 values), job (1 values)
+
+## myapp_db
+
+- `myapp_db_connections_active` (gauge) — Number of active DB connections.
+  Labels: instance (1 values), job (1 values)
+- `myapp_db_connections_idle` (gauge) — Number of idle DB connections.
+  Labels: instance (1 values), job (1 values)
+- `myapp_db_query_duration_seconds_bucket`
+  Labels: instance (1 values), job (1 values), le (12 values), operation (2 values)
+- `myapp_db_query_duration_seconds_count`
+  Labels: instance (1 values), job (1 values), operation (2 values)
+- `myapp_db_query_duration_seconds_sum`
+  Labels: instance (1 values), job (1 values), operation (2 values)
+
+## myapp_errors
+
+- `myapp_errors_total` (counter) — Total errors by type.
+  Labels: instance (1 values), job (1 values), type (4 values)
+
+## myapp_http
+
+- `myapp_http_request_duration_seconds_bucket`
+  Labels: instance (1 values), job (1 values), le (12 values), method (2 values), path (4 values)
+- `myapp_http_request_duration_seconds_count`
+  Labels: instance (1 values), job (1 values), method (2 values), path (4 values)
+- `myapp_http_request_duration_seconds_sum`
+  Labels: instance (1 values), job (1 values), method (2 values), path (4 values)
+- `myapp_http_requests_in_flight` (gauge) — Number of HTTP requests currently in flight.
+  Labels: instance (1 values), job (1 values)
+- `myapp_http_requests_total` (counter) — Total HTTP requests.
+  Labels: instance (1 values), job (1 values), method (2 values), path (4 values), status (2 values)
+
+## myapp_jobs
+
+- `myapp_jobs_duration_seconds_bucket`
+  Labels: instance (1 values), job (1 values), le (12 values), queue (3 values)
+- `myapp_jobs_duration_seconds_count`
+  Labels: instance (1 values), job (1 values), queue (3 values)
+- `myapp_jobs_duration_seconds_sum`
+  Labels: instance (1 values), job (1 values), queue (3 values)
+- `myapp_jobs_processed_total` (counter) — Total background jobs processed.
+  Labels: instance (1 values), job (1 values), queue (3 values), status (2 values)
+- `myapp_jobs_queue_depth` (gauge) — Number of pending jobs in queue.
+  Labels: instance (1 values), job (1 values), queue (3 values)
+
+## myapp_orders
+
+- `myapp_orders_created_total` (counter) — Total orders created.
+  Labels: instance (1 values), job (1 values), status (3 values)
+
+## myapp_revenue
+
+- `myapp_revenue_total` (counter) — Total revenue.
+  Labels: currency (1 values), instance (1 values), job (1 values)
+
+## myapp_users
+
+- `myapp_users_active` (gauge) — Number of currently active users.
+  Labels: instance (1 values), job (1 values)
+- `myapp_users_registered_total` (counter) — Total user registrations.
   Labels: instance (1 values), job (1 values)
 
 ## process_cpu
 
 - `process_cpu_seconds_total` (counter) — Total user and system CPU time spent in seconds.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 
 ## process_max
 
 - `process_max_fds` (gauge) — Maximum number of open file descriptors.
+  Labels: instance (2 values), job (2 values)
+
+## process_network
+
+- `process_network_receive_bytes_total` (counter) — Number of bytes received by the process over the network.
+  Labels: instance (1 values), job (1 values)
+- `process_network_transmit_bytes_total` (counter) — Number of bytes sent by the process over the network.
   Labels: instance (1 values), job (1 values)
 
 ## process_open
 
 - `process_open_fds` (gauge) — Number of open file descriptors.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 
 ## process_resident
 
 - `process_resident_memory_bytes` (gauge) — Resident memory size in bytes.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 
 ## process_start
 
 - `process_start_time_seconds` (gauge) — Start time of the process since unix epoch in seconds.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 
 ## process_virtual
 
 - `process_virtual_memory_bytes` (gauge) — Virtual memory size in bytes.
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 - `process_virtual_memory_max_bytes` (gauge) — Maximum amount of virtual memory available in bytes.
+  Labels: instance (2 values), job (2 values)
+
+## promhttp_metric
+
+- `promhttp_metric_handler_requests_in_flight` (gauge) — Current number of scrapes being served.
   Labels: instance (1 values), job (1 values)
+- `promhttp_metric_handler_requests_total` (counter) — Total number of scrapes by HTTP status code.
+  Labels: code (3 values), instance (1 values), job (1 values)
 
 ## redis_clients
 
@@ -174,19 +265,19 @@
 ## scrape_duration
 
 - `scrape_duration_seconds`
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 
 ## scrape_samples
 
 - `scrape_samples_post_metric_relabeling`
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 - `scrape_samples_scraped`
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 
 ## scrape_series
 
 - `scrape_series_added`
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 
 ## system_cpu
 
@@ -288,7 +379,7 @@
 ## up
 
 - `up`
-  Labels: instance (1 values), job (1 values)
+  Labels: instance (2 values), job (2 values)
 
 # Label Values
 
@@ -296,90 +387,100 @@ Full label value listings for each metric.
 
 ## go_gc_duration_seconds
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 - **quantile**: 0.0, 0.25, 0.5, 0.75, 1.0
 
 ## go_gc_duration_seconds_count
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_gc_duration_seconds_sum
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
+
+## go_gc_gogc_percent
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## go_gc_gomemlimit_bytes
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
 
 ## go_goroutines
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_info
 
-- **instance**: traefik:8080
-- **job**: traefik
-- **version**: go1.24.5
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
+- **version**: go1.24.5, go1.25.6
 
 ## go_memstats_alloc_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_alloc_bytes_total
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_buck_hash_sys_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_frees_total
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_gc_sys_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_heap_alloc_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_heap_idle_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_heap_inuse_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_heap_objects
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_heap_released_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_heap_sys_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_last_gc_time_seconds
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_lookups_total
 
@@ -388,93 +489,253 @@ Full label value listings for each metric.
 
 ## go_memstats_mallocs_total
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_mcache_inuse_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_mcache_sys_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_mspan_inuse_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_mspan_sys_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_next_gc_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_other_sys_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_stack_inuse_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_stack_sys_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## go_memstats_sys_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
+
+## go_sched_gomaxprocs_threads
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
 
 ## go_threads
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
+
+## myapp_cache_hits_total
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## myapp_cache_misses_total
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## myapp_db_connections_active
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## myapp_db_connections_idle
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## myapp_db_query_duration_seconds_bucket
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **le**: +Inf, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 10.0, 2.5, 5.0
+- **operation**: insert, select
+
+## myapp_db_query_duration_seconds_count
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **operation**: insert, select
+
+## myapp_db_query_duration_seconds_sum
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **operation**: insert, select
+
+## myapp_errors_total
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **type**: connection_refused, internal, timeout, validation
+
+## myapp_http_request_duration_seconds_bucket
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **le**: +Inf, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 10.0, 2.5, 5.0
+- **method**: GET, POST
+- **path**: /, /api/orders, /api/search, /api/users
+
+## myapp_http_request_duration_seconds_count
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **method**: GET, POST
+- **path**: /, /api/orders, /api/search, /api/users
+
+## myapp_http_request_duration_seconds_sum
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **method**: GET, POST
+- **path**: /, /api/orders, /api/search, /api/users
+
+## myapp_http_requests_in_flight
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## myapp_http_requests_total
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **method**: GET, POST
+- **path**: /, /api/orders, /api/search, /api/users
+- **status**: 200, 500
+
+## myapp_jobs_duration_seconds_bucket
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **le**: +Inf, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 10.0, 2.5, 5.0
+- **queue**: cleanup, email, export
+
+## myapp_jobs_duration_seconds_count
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **queue**: cleanup, email, export
+
+## myapp_jobs_duration_seconds_sum
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **queue**: cleanup, email, export
+
+## myapp_jobs_processed_total
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **queue**: cleanup, email, export
+- **status**: failure, success
+
+## myapp_jobs_queue_depth
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **queue**: cleanup, email, export
+
+## myapp_orders_created_total
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+- **status**: cancelled, completed, failed
+
+## myapp_revenue_total
+
+- **currency**: USD
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## myapp_users_active
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## myapp_users_registered_total
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
 
 ## process_cpu_seconds_total
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## process_max_fds
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
+
+## process_network_receive_bytes_total
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## process_network_transmit_bytes_total
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
 
 ## process_open_fds
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## process_resident_memory_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## process_start_time_seconds
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## process_virtual_memory_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## process_virtual_memory_max_bytes
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
+
+## promhttp_metric_handler_requests_in_flight
+
+- **instance**: dummyapp:3000
+- **job**: dummyapp
+
+## promhttp_metric_handler_requests_total
+
+- **code**: 200, 500, 503
+- **instance**: dummyapp:3000
+- **job**: dummyapp
 
 ## redis_cpu_time_seconds_total
 
@@ -482,23 +743,23 @@ Full label value listings for each metric.
 
 ## scrape_duration_seconds
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## scrape_samples_post_metric_relabeling
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## scrape_samples_scraped
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## scrape_series_added
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 
 ## system_cpu_time_seconds_total
 
@@ -756,6 +1017,6 @@ Full label value listings for each metric.
 
 ## up
 
-- **instance**: traefik:8080
-- **job**: traefik
+- **instance**: dummyapp:3000, traefik:8080
+- **job**: dummyapp, traefik
 

--- a/examples/real-world/prometheus.yaml
+++ b/examples/real-world/prometheus.yaml
@@ -8,3 +8,7 @@ scrape_configs:
   - job_name: "traefik"
     static_configs:
       - targets: ["traefik:8080"]
+
+  - job_name: "dummyapp"
+    static_configs:
+      - targets: ["dummyapp:3000"]


### PR DESCRIPTION
## Summary
- Reorganize `examples/` into `kitchensink/` and `real-world/` subdirectories
- Add CI validation for example config and dashboard YAML files
- Add `cmd/dummyapp`: a simulated web application exposing custom Prometheus metrics (HTTP RED, business KPIs, job queues, DB pool, cache stats) for the real-world example
- Regenerate dashboards and prompt files with the new application metrics

## Test plan
- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes
- [x] `cd frontend && npm run build` passes
- [x] `docker compose build dummyapp` succeeds
- [x] `make gen-prompt` discovers 131 metrics including all `myapp_*` metrics
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)