### PR TITLE
Remove unnecessary host port mappings and local dev targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,9 @@ make screenshots                 # Regenerate README screenshots (Docker)
 cd frontend && npm run build     # Frontend build (TypeScript check + Vite)
 ```
 
-Development (three terminals):
+Development (all services run in Docker):
 ```bash
-make dev-dummyprom               # Fake Prometheus on :9090
-make dev-backend                 # Go server on :8080 (uses examples/kitchensink/config.yaml)
-make dev-frontend                # Vite dev server on :5173
-make dev-dummygithub             # Fake GitHub OAuth server on :5555
+make gen-prompt-up               # Start full real-world stack (dashyard on :8080)
 ```
 
 ## Project Layout

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all frontend backend build test test-frontend test-e2e lint clean dev-frontend dev-backend dev-dummyprom dev-dummygithub screenshots gen-prompt gen-prompt-up
+.PHONY: all frontend backend build test test-frontend test-e2e lint clean screenshots gen-prompt gen-prompt-up
 
 all: build
 
@@ -22,18 +22,6 @@ test-e2e:
 lint:
 	golangci-lint run ./...
 	cd frontend && npm run lint
-
-dev-frontend:
-	cd frontend && npm run dev
-
-dev-backend:
-	go run . serve --config examples/kitchensink/config.yaml --dashboards-dir examples/kitchensink/dashboards
-
-dev-dummyprom:
-	go run ./cmd/dummyprom
-
-dev-dummygithub:
-	go run ./cmd/dummygithub
 
 screenshots:
 	docker compose -f docker-compose.screenshots.yaml up --build --abort-on-container-exit screenshots

--- a/examples/kitchensink/docker-compose.yaml
+++ b/examples/kitchensink/docker-compose.yaml
@@ -16,5 +16,3 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile.dummyprom
-    ports:
-      - "9090:9090"

--- a/examples/real-world/docker-compose.yaml
+++ b/examples/real-world/docker-compose.yaml
@@ -8,8 +8,6 @@ services:
       - --storage.tsdb.retention.time=1h
     volumes:
       - ./prometheus.yaml:/etc/prometheus/prometheus.yml:ro
-    ports:
-      - "9090:9090"
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/-/healthy || exit 1"]
       interval: 5s
@@ -32,8 +30,6 @@ services:
     volumes:
       - ./traefik.yaml:/etc/traefik/traefik.yml:ro
       - ./traefik-dynamic.yaml:/etc/traefik/dynamic.yml:ro
-    ports:
-      - "8888:80"
     depends_on:
       - whoami
 
@@ -46,8 +42,6 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile.dummyapp
-    ports:
-      - "3000:3000"
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/healthz || exit 1"]
       interval: 5s
@@ -57,8 +51,6 @@ services:
   # --- Redis ---
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
 
   # --- Traffic generator ---
   traffic-gen:


### PR DESCRIPTION
## Summary
- Remove host port exposure from docker-compose services that only need container-to-container communication (prometheus, traefik, dummyapp, redis, dummyprom). Dashyard keeps `8080:8080` for browser access.
- Remove `make dev-*` targets (`dev-frontend`, `dev-backend`, `dev-dummyprom`, `dev-dummygithub`) — all services run in Docker.
- Update CLAUDE.md development section accordingly.

This eliminates port conflicts between docker-compose and locally running Go processes.

## Test plan
- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes
- [x] `make gen-prompt` completes without port conflicts
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)