### PR TITLE
Add Docker-based E2E test runner

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/playwright:v1.58.1-noble
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/playwright.config.ts frontend/tsconfig.json ./
+COPY frontend/e2e/ ./e2e/
+CMD ["npx", "playwright", "test"]

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ test-frontend:
 	cd frontend && npm run test
 
 test-e2e:
-	cd frontend && npx playwright test
+	docker compose -f docker-compose.e2e.yaml up --build --exit-code-from e2e e2e; \
+	rc=$$?; \
+	docker compose -f docker-compose.e2e.yaml down; \
+	exit $$rc
 
 lint:
 	golangci-lint run ./...

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -1,0 +1,67 @@
+services:
+  dummyprom:
+    build:
+      context: .
+      dockerfile: Dockerfile.dummyprom
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/api/v1/label/cpu/values || exit 1"]
+      interval: 3s
+      timeout: 5s
+      retries: 5
+
+  dummygithub:
+    build:
+      context: .
+      dockerfile: Dockerfile.dummygithub
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:5555/api/v3/user || exit 1"]
+      interval: 3s
+      timeout: 5s
+      retries: 5
+
+  dashyard:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./examples/kitchensink/config-docker.yaml:/etc/dashyard/config.yaml:ro
+      - ./examples/kitchensink/dashboards:/etc/dashyard/dashboards:ro
+    depends_on:
+      dummyprom:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/ || exit 1"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
+
+  dashyard-oauth:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./examples/kitchensink/config-docker-oauth.yaml:/etc/dashyard/config.yaml:ro
+      - ./examples/kitchensink/dashboards:/etc/dashyard/dashboards:ro
+    depends_on:
+      dummyprom:
+        condition: service_healthy
+      dummygithub:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/ || exit 1"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
+
+  e2e:
+    build:
+      context: .
+      dockerfile: Dockerfile.e2e
+    environment:
+      BASE_URL: http://dashyard:8080
+      OAUTH_BASE_URL: http://dashyard-oauth:8080
+    depends_on:
+      dashyard:
+        condition: service_healthy
+      dashyard-oauth:
+        condition: service_healthy

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -16,7 +16,8 @@ async function globalSetup(_config: FullConfig) {
   const context = await browser.newContext();
   const page = await context.newPage();
 
-  await page.goto("http://localhost:5173/");
+  const baseURL = process.env.BASE_URL || "http://localhost:5173";
+  await page.goto(`${baseURL}/`);
 
   // Wait for login form inputs to render (not just the container, which may
   // show a "Loading..." state while /api/auth-info is being fetched)

--- a/frontend/e2e/oauth-login.spec.ts
+++ b/frontend/e2e/oauth-login.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "@playwright/test";
 
+const oauthBaseURL =
+  process.env.OAUTH_BASE_URL ||
+  process.env.BASE_URL ||
+  "http://localhost:5173";
+
 // OAuth tests don't use the global auth state
 test.use({ storageState: { cookies: [], origins: [] } });
 
@@ -7,7 +12,7 @@ test.describe("OAuth Login", () => {
   test("login page shows OAuth button when provider is configured", async ({
     page,
   }) => {
-    await page.goto("/");
+    await page.goto(`${oauthBaseURL}/`);
 
     // Wait for login form to render
     await expect(page.locator(".login-form")).toBeVisible({ timeout: 10000 });
@@ -19,7 +24,7 @@ test.describe("OAuth Login", () => {
   });
 
   test("login page shows both OAuth and password form", async ({ page }) => {
-    await page.goto("/");
+    await page.goto(`${oauthBaseURL}/`);
 
     await expect(page.locator(".login-form")).toBeVisible({ timeout: 10000 });
 
@@ -35,7 +40,7 @@ test.describe("OAuth Login", () => {
   });
 
   test("OAuth flow through dummygithub completes login", async ({ page }) => {
-    await page.goto("/");
+    await page.goto(`${oauthBaseURL}/`);
 
     // Wait for login form
     await expect(page.locator(".login-form")).toBeVisible({ timeout: 10000 });
@@ -55,8 +60,8 @@ test.describe("OAuth Login", () => {
     // This navigates: dummygithub → callback → redirect to /
     await page.getByRole("link", { name: "Sign in as dummyuser" }).click();
 
-    // Wait until we're back on the app (URL contains localhost:5173)
-    await page.waitForURL("http://localhost:5173/**", { timeout: 15000 });
+    // Wait until we're back on the app
+    await page.waitForURL(`${oauthBaseURL}/**`, { timeout: 15000 });
 
     // The OAuth callback sets a session cookie and redirects to /.
     // Reload to ensure the app picks up the session.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   reporter: "html",
   globalSetup: "./e2e/global-setup.ts",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: process.env.BASE_URL || "http://localhost:5173",
     storageState: "./e2e/.auth/session.json",
     trace: "on-first-retry",
   },


### PR DESCRIPTION
## Summary
- Add `Dockerfile.e2e` and `docker-compose.e2e.yaml` to run Playwright E2E tests entirely inside Docker
- Update `make test-e2e` to use Docker Compose with `--exit-code-from` for proper failure propagation
- Make `playwright.config.ts`, `global-setup.ts`, and `oauth-login.spec.ts` configurable via `BASE_URL` / `OAUTH_BASE_URL` env vars (falls back to `localhost:5173` for local dev)

## Test plan
- [x] `make test-e2e` passes with all 28 tests green
- [x] Intentionally broken test returns non-zero exit code from `make test-e2e`
- [ ] Local `cd frontend && npx playwright test` still works (env var fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)