### PR TITLE
Introduce Datasource interface to decouple handlers from Prometheus

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { Dashboard, DashboardsResponse, DatasourcesResponse, LabelValuesResponse, PrometheusResponse } from '../types';
+import type { Dashboard, DashboardsResponse, DatasourcesResponse, LabelValuesResponse, QueryResponse } from '../types';
 
 export interface OAuthProviderInfo {
   name: string;
@@ -49,13 +49,13 @@ export async function fetchDashboard(path: string): Promise<Dashboard> {
   return request(`/api/dashboards/${path}`);
 }
 
-export async function queryPrometheus(
+export async function queryDatasource(
   query: string,
   start: number,
   end: number,
   step: string,
   datasource?: string,
-): Promise<PrometheusResponse> {
+): Promise<QueryResponse> {
   const params = new URLSearchParams({
     query,
     start: start.toString(),

--- a/frontend/src/components/GraphPanel.tsx
+++ b/frontend/src/components/GraphPanel.tsx
@@ -15,7 +15,7 @@ import {
 } from 'chart.js';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import 'chartjs-adapter-date-fns';
-import type { PrometheusResponse, Threshold } from '../types';
+import type { QueryResponse, Threshold } from '../types';
 import { getYAxisTickCallback } from '../utils/units';
 
 ChartJS.register(
@@ -35,7 +35,7 @@ ChartJS.register(
 
 interface GraphPanelProps {
   title: string;
-  data: PrometheusResponse | null;
+  data: QueryResponse | null;
   unit?: string;
   yMin?: number;
   yMax?: number;

--- a/frontend/src/hooks/useQuery.ts
+++ b/frontend/src/hooks/useQuery.ts
@@ -1,16 +1,16 @@
 import { useState, useEffect } from 'react';
-import { queryPrometheus, ApiError } from '../api/client';
-import type { PrometheusResponse, TimeRange } from '../types';
+import { queryDatasource, ApiError } from '../api/client';
+import type { QueryResponse, TimeRange } from '../types';
 import { getTimeRangeParams } from '../utils/time';
 
 interface UseQueryResult {
-  data: PrometheusResponse | null;
+  data: QueryResponse | null;
   loading: boolean;
   error: string | null;
 }
 
 export function useQuery(query: string | undefined, timeRange: TimeRange, datasource?: string): UseQueryResult {
-  const [data, setData] = useState<PrometheusResponse | null>(null);
+  const [data, setData] = useState<QueryResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -23,7 +23,7 @@ export function useQuery(query: string | undefined, timeRange: TimeRange, dataso
 
     const { start, end, step } = getTimeRangeParams(timeRange);
 
-    queryPrometheus(query, start, end, step, datasource)
+    queryDatasource(query, start, end, step, datasource)
       .then((result) => {
         if (!cancelled) {
           setData(result);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -70,16 +70,16 @@ export interface DashboardsResponse {
   header_color: string;
 }
 
-export interface PrometheusResult {
+export interface QueryResult {
   metric: Record<string, string>;
   values: [number, string][];
 }
 
-export interface PrometheusResponse {
+export interface QueryResponse {
   status: string;
   data: {
     resultType: string;
-    result: PrometheusResult[];
+    result: QueryResult[];
   };
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,8 +145,9 @@ func validateDatasources(datasources []DatasourceConfig) error {
 		}
 		seen[ds.Name] = true
 
-		if ds.Type != "prometheus" {
-			return fmt.Errorf("datasources[%d]: unsupported type %q (only \"prometheus\" is supported)", i, ds.Type)
+		validTypes := map[string]bool{"prometheus": true}
+		if !validTypes[ds.Type] {
+			return fmt.Errorf("datasources[%d]: unsupported type %q", i, ds.Type)
 		}
 		if ds.URL == "" {
 			return fmt.Errorf("datasources[%d]: url is required", i)

--- a/internal/datasource/datasource.go
+++ b/internal/datasource/datasource.go
@@ -1,0 +1,14 @@
+package datasource
+
+import (
+	"context"
+	"io"
+)
+
+// Datasource defines the interface for querying a metrics backend.
+// Handlers use this interface so they are not coupled to a specific implementation.
+type Datasource interface {
+	QueryRange(ctx context.Context, query, start, end, step string) (io.ReadCloser, int, error)
+	Ping(ctx context.Context) error
+	LabelValues(ctx context.Context, label, match string) (io.ReadCloser, int, error)
+}

--- a/internal/datasource/registry_test.go
+++ b/internal/datasource/registry_test.go
@@ -13,7 +13,10 @@ func TestNewRegistry(t *testing.T) {
 		{Name: "app", Type: "prometheus", URL: "http://app:9090", Timeout: 15 * time.Second},
 	}
 
-	reg := NewRegistry(datasources)
+	reg, err := NewRegistry(datasources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if reg.DefaultName() != "main" {
 		t.Errorf("expected default name 'main', got %q", reg.DefaultName())
@@ -29,7 +32,10 @@ func TestRegistryGet(t *testing.T) {
 		{Name: "app", Type: "prometheus", URL: "http://app:9090", Timeout: 15 * time.Second},
 	}
 
-	reg := NewRegistry(datasources)
+	reg, err := NewRegistry(datasources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	client, err := reg.Get("main")
 	if err != nil {
@@ -69,7 +75,10 @@ func TestRegistryNames(t *testing.T) {
 		{Name: "alpha", Type: "prometheus", URL: "http://a:9090", Timeout: 30 * time.Second, Default: true},
 	}
 
-	reg := NewRegistry(datasources)
+	reg, err := NewRegistry(datasources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	names := reg.Names()
 	if len(names) != 2 {
@@ -77,5 +86,16 @@ func TestRegistryNames(t *testing.T) {
 	}
 	if names[0] != "alpha" || names[1] != "beta" {
 		t.Errorf("expected sorted names [alpha, beta], got %v", names)
+	}
+}
+
+func TestNewRegistryUnsupportedType(t *testing.T) {
+	datasources := []config.DatasourceConfig{
+		{Name: "main", Type: "influxdb", URL: "http://main:8086", Timeout: 30 * time.Second, Default: true},
+	}
+
+	_, err := NewRegistry(datasources)
+	if err == nil {
+		t.Fatal("expected error for unsupported datasource type")
 	}
 }

--- a/internal/handler/datasources_test.go
+++ b/internal/handler/datasources_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDatasourcesHandler(t *testing.T) {
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "prod", Type: "prometheus", URL: "http://prom-prod:9090", Timeout: 5 * time.Second, Default: true},
 		{Name: "staging", Type: "prometheus", URL: "http://prom-staging:9090", Timeout: 5 * time.Second},
 	})
@@ -51,7 +51,7 @@ func TestDatasourcesHandler(t *testing.T) {
 }
 
 func TestDatasourcesHandlerSingle(t *testing.T) {
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: "http://localhost:9090", Timeout: 5 * time.Second, Default: true},
 	})
 	handler := NewDatasourcesHandler(registry)

--- a/internal/handler/label_values.go
+++ b/internal/handler/label_values.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tokuhirom/dashyard/internal/datasource"
 )
 
-// LabelValuesHandler handles GET /api/label-values - proxies label values requests to Prometheus.
+// LabelValuesHandler handles GET /api/label-values - proxies label values requests to the datasource.
 type LabelValuesHandler struct {
 	registry *datasource.Registry
 }
@@ -19,7 +19,7 @@ func NewLabelValuesHandler(registry *datasource.Registry) *LabelValuesHandler {
 	return &LabelValuesHandler{registry: registry}
 }
 
-// Handle processes a Prometheus label values proxy request.
+// Handle processes a datasource label values proxy request.
 func (h *LabelValuesHandler) Handle(c *gin.Context) {
 	label := c.Query("label")
 	if label == "" {
@@ -37,8 +37,8 @@ func (h *LabelValuesHandler) Handle(c *gin.Context) {
 
 	body, statusCode, err := client.LabelValues(c.Request.Context(), label, match)
 	if err != nil {
-		slog.Error("prometheus label values query failed", "error", err)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "prometheus label values query failed"})
+		slog.Error("datasource label values query failed", "error", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "datasource label values query failed"})
 		return
 	}
 	defer func() { _ = body.Close() }()
@@ -46,6 +46,6 @@ func (h *LabelValuesHandler) Handle(c *gin.Context) {
 	c.Header("Content-Type", "application/json")
 	c.Status(statusCode)
 	if _, err := io.Copy(c.Writer, body); err != nil {
-		slog.Error("failed to stream prometheus response", "error", err)
+		slog.Error("failed to stream datasource response", "error", err)
 	}
 }

--- a/internal/handler/label_values_test.go
+++ b/internal/handler/label_values_test.go
@@ -19,7 +19,7 @@ func TestLabelValuesHandler(t *testing.T) {
 	}))
 	defer promServer.Close()
 
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: promServer.URL, Timeout: 5 * time.Second, Default: true},
 	})
 	handler := NewLabelValuesHandler(registry)
@@ -42,7 +42,7 @@ func TestLabelValuesHandler(t *testing.T) {
 }
 
 func TestLabelValuesHandlerMissingLabel(t *testing.T) {
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: "http://localhost:9090", Timeout: 5 * time.Second, Default: true},
 	})
 	handler := NewLabelValuesHandler(registry)
@@ -66,7 +66,7 @@ func TestLabelValuesHandlerPrometheusError(t *testing.T) {
 	}))
 	defer promServer.Close()
 
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: promServer.URL, Timeout: 5 * time.Second, Default: true},
 	})
 	handler := NewLabelValuesHandler(registry)
@@ -90,7 +90,7 @@ func TestLabelValuesHandlerWithDatasourceParam(t *testing.T) {
 	}))
 	defer promServer.Close()
 
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "main", Type: "prometheus", URL: "http://localhost:1", Timeout: 5 * time.Second, Default: true},
 		{Name: "app", Type: "prometheus", URL: promServer.URL, Timeout: 5 * time.Second},
 	})

--- a/internal/handler/query.go
+++ b/internal/handler/query.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tokuhirom/dashyard/internal/datasource"
 )
 
-// QueryHandler handles GET /api/query - proxies requests to Prometheus.
+// QueryHandler handles GET /api/query - proxies requests to the datasource.
 type QueryHandler struct {
 	registry *datasource.Registry
 }
@@ -19,7 +19,7 @@ func NewQueryHandler(registry *datasource.Registry) *QueryHandler {
 	return &QueryHandler{registry: registry}
 }
 
-// Handle processes a Prometheus query_range proxy request.
+// Handle processes a datasource query_range proxy request.
 func (h *QueryHandler) Handle(c *gin.Context) {
 	query := c.Query("query")
 	start := c.Query("start")
@@ -39,8 +39,8 @@ func (h *QueryHandler) Handle(c *gin.Context) {
 
 	body, statusCode, err := client.QueryRange(c.Request.Context(), query, start, end, step)
 	if err != nil {
-		slog.Error("prometheus query failed", "error", err)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "prometheus query failed"})
+		slog.Error("datasource query failed", "error", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "datasource query failed"})
 		return
 	}
 	defer func() { _ = body.Close() }()
@@ -48,6 +48,6 @@ func (h *QueryHandler) Handle(c *gin.Context) {
 	c.Header("Content-Type", "application/json")
 	c.Status(statusCode)
 	if _, err := io.Copy(c.Writer, body); err != nil {
-		slog.Error("failed to stream prometheus response", "error", err)
+		slog.Error("failed to stream datasource response", "error", err)
 	}
 }

--- a/internal/handler/query_test.go
+++ b/internal/handler/query_test.go
@@ -20,7 +20,7 @@ func TestQueryHandler(t *testing.T) {
 	}))
 	defer promServer.Close()
 
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: promServer.URL, Timeout: 5 * time.Second, Default: true},
 	})
 	handler := NewQueryHandler(registry)
@@ -43,7 +43,7 @@ func TestQueryHandler(t *testing.T) {
 }
 
 func TestQueryHandlerMissingParams(t *testing.T) {
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: "http://localhost:9090", Timeout: 5 * time.Second, Default: true},
 	})
 	handler := NewQueryHandler(registry)
@@ -81,7 +81,7 @@ func TestQueryHandlerPrometheusError(t *testing.T) {
 	}))
 	defer promServer.Close()
 
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: promServer.URL, Timeout: 5 * time.Second, Default: true},
 	})
 	handler := NewQueryHandler(registry)
@@ -111,7 +111,7 @@ func TestQueryHandlerWithDatasourceParam(t *testing.T) {
 	}))
 	defer appServer.Close()
 
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "main", Type: "prometheus", URL: mainServer.URL, Timeout: 5 * time.Second, Default: true},
 		{Name: "app", Type: "prometheus", URL: appServer.URL, Timeout: 5 * time.Second},
 	})

--- a/internal/handler/ready_test.go
+++ b/internal/handler/ready_test.go
@@ -21,7 +21,7 @@ func TestReadyHandler_OK(t *testing.T) {
 	}))
 	defer promServer.Close()
 
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: promServer.URL, Timeout: 5 * time.Second, Default: true},
 	})
 	h := NewReadyHandler(registry)
@@ -54,7 +54,7 @@ func TestReadyHandler_OK(t *testing.T) {
 }
 
 func TestReadyHandler_PrometheusUnreachable(t *testing.T) {
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: "http://localhost:1", Timeout: 1 * time.Second, Default: true},
 	})
 	h := NewReadyHandler(registry)
@@ -92,7 +92,7 @@ func TestReadyHandler_PrometheusNotReady(t *testing.T) {
 	}))
 	defer promServer.Close()
 
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "default", Type: "prometheus", URL: promServer.URL, Timeout: 5 * time.Second, Default: true},
 	})
 	h := NewReadyHandler(registry)
@@ -130,7 +130,7 @@ func TestReadyHandler_MultipleDatasources(t *testing.T) {
 	}))
 	defer goodServer.Close()
 
-	registry := datasource.NewRegistry([]config.DatasourceConfig{
+	registry, _ := datasource.NewRegistry([]config.DatasourceConfig{
 		{Name: "good", Type: "prometheus", URL: goodServer.URL, Timeout: 5 * time.Second, Default: true},
 		{Name: "bad", Type: "prometheus", URL: "http://localhost:1", Timeout: 1 * time.Second},
 	})

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,16 +19,16 @@ var (
 	}, []string{"method", "path"})
 )
 
-// Prometheus proxy metrics.
+// Datasource proxy metrics.
 var (
-	PrometheusQueryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "dashyard_prometheus_query_total",
-		Help: "Total number of upstream Prometheus queries.",
+	DatasourceQueryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "dashyard_datasource_query_total",
+		Help: "Total number of upstream datasource queries.",
 	}, []string{"status"})
 
-	PrometheusQueryDuration = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "dashyard_prometheus_query_duration_seconds",
-		Help:    "Upstream Prometheus query latency in seconds.",
+	DatasourceQueryDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "dashyard_datasource_query_duration_seconds",
+		Help:    "Upstream datasource query latency in seconds.",
 		Buckets: prometheus.DefBuckets,
 	})
 )

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -73,16 +73,16 @@ func (c *Client) QueryRange(ctx context.Context, query, start, end, step string)
 	reqStart := time.Now()
 	resp, err := c.httpClient.Do(req)
 	duration := time.Since(reqStart).Seconds()
-	metrics.PrometheusQueryDuration.Observe(duration)
+	metrics.DatasourceQueryDuration.Observe(duration)
 	if err != nil {
-		metrics.PrometheusQueryTotal.WithLabelValues("error").Inc()
+		metrics.DatasourceQueryTotal.WithLabelValues("error").Inc()
 		return nil, 0, fmt.Errorf("executing request: %w", err)
 	}
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		metrics.PrometheusQueryTotal.WithLabelValues("success").Inc()
+		metrics.DatasourceQueryTotal.WithLabelValues("success").Inc()
 	} else {
-		metrics.PrometheusQueryTotal.WithLabelValues("error").Inc()
+		metrics.DatasourceQueryTotal.WithLabelValues("error").Inc()
 	}
 
 	return resp.Body, resp.StatusCode, nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,7 +44,10 @@ func New(cfg *config.Config, holder *dashboard.StoreHolder, frontendFS fs.FS, ho
 	}
 
 	// Datasource registry
-	registry := datasource.NewRegistry(cfg.Datasources)
+	registry, err := datasource.NewRegistry(cfg.Datasources)
+	if err != nil {
+		return nil, fmt.Errorf("creating datasource registry: %w", err)
+	}
 
 	// Handlers
 	loginHandler := handler.NewLoginHandler(cfg.Users, sm)


### PR DESCRIPTION
## Summary

- Add `Datasource` interface (`QueryRange`, `Ping`, `LabelValues`) in `internal/datasource/datasource.go` so handlers are not coupled to `*prometheus.Client`
- Change `Registry` to store `map[string]Datasource` with a type-switch in `NewRegistry` (returns error for unsupported types)
- Rename Go metrics variables and Prometheus metric names from `prometheus_query` to `datasource_query`
- Update handler comments and error messages from "prometheus" to "datasource"
- Use `validTypes` map in config validation instead of hardcoded `!= "prometheus"` check
- Rename frontend types: `PrometheusResponse` → `QueryResponse`, `PrometheusResult` → `QueryResult`, `queryPrometheus()` → `queryDatasource()`

## Test plan

- [x] `go test ./...` — all passing
- [x] `golangci-lint run ./...` — 0 issues
- [x] `cd frontend && npm run build` — TypeScript check + Vite build successful
- [ ] `make test-e2e` — E2E tests (to be verified in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)