### PR TITLE
Add cookie_secure option to server config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type AuthConfig struct {
 // ServerConfig holds HTTP server settings.
 type ServerConfig struct {
 	SessionSecret  string   `yaml:"session_secret"`
+	CookieSecure   bool     `yaml:"cookie_secure"`
 	TrustedProxies []string `yaml:"trusted_proxies,omitempty"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -101,6 +101,36 @@ func TestParseDefaults(t *testing.T) {
 	}
 }
 
+func TestParseCookieSecure(t *testing.T) {
+	input := []byte(`
+server:
+  session_secret: "test"
+  cookie_secure: true
+`)
+
+	cfg, err := Parse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.Server.CookieSecure {
+		t.Error("expected cookie_secure to be true")
+	}
+}
+
+func TestParseCookieSecureDefault(t *testing.T) {
+	input := []byte(`{}`)
+
+	cfg, err := Parse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Server.CookieSecure {
+		t.Error("expected cookie_secure to default to false")
+	}
+}
+
 func TestParseTrustedProxies(t *testing.T) {
 	input := []byte(`
 server:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,7 +35,7 @@ func New(cfg *config.Config, holder *dashboard.StoreHolder, frontendFS fs.FS, ho
 	}
 
 	// Session manager
-	sm := auth.NewSessionManager(cfg.Server.SessionSecret, false)
+	sm := auth.NewSessionManager(cfg.Server.SessionSecret, cfg.Server.CookieSecure)
 
 	// Initialize OAuth providers and set gothic store
 	if len(cfg.Auth.OAuth) > 0 {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -23,6 +23,11 @@
           "type": "string",
           "description": "Secret key for session signing. Auto-generated if omitted."
         },
+        "cookie_secure": {
+          "type": "boolean",
+          "description": "Set the Secure flag on session cookies. Enable when serving over HTTPS (directly or behind a TLS-terminating reverse proxy).",
+          "default": false
+        },
         "trusted_proxies": {
           "type": "array",
           "description": "List of IP addresses or CIDRs trusted to set X-Forwarded-For headers.",


### PR DESCRIPTION
## Summary

- Add `server.cookie_secure` boolean field to `ServerConfig` so the Secure flag on session cookies can be enabled for HTTPS deployments
- Pass the config value through to `auth.NewSessionManager` in `server.go` (previously hardcoded to `false`)
- Update JSON schema with the new property
- Add tests for the new config field (explicit `true` and default `false`)

Fixes #124

## Test plan

- [x] `go test ./...` — all passing
- [x] `golangci-lint run ./...` — 0 issues

### Usage

```yaml
server:
  session_secret: "my-secret"
  cookie_secure: true  # enable for HTTPS deployments
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)