### PR TITLE
Improve internal/auth test coverage from 63.8% to 94.7%

### DIFF
--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -75,6 +75,26 @@ func TestAuthMiddlewareNoCookie(t *testing.T) {
 	}
 }
 
+func TestGetUserIDNoSession(t *testing.T) {
+	router := gin.New()
+	router.GET("/test", func(c *gin.Context) {
+		userID := GetUserID(c)
+		c.JSON(http.StatusOK, gin.H{"user_id": userID})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	var body map[string]string
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["user_id"] != "" {
+		t.Errorf("expected empty user_id, got %q", body["user_id"])
+	}
+}
+
 func TestAuthMiddlewareInvalidCookie(t *testing.T) {
 	sm := NewSessionManager("test-secret-that-is-32bytes!!", false)
 

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/markbates/goth"
@@ -96,6 +98,132 @@ func TestInitGothProvidersWithBaseURL(t *testing.T) {
 	}
 	if p.Name() != "github" {
 		t.Errorf("expected provider name 'github', got %q", p.Name())
+	}
+}
+
+func TestFetchGitHubOrgs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("expected Bearer test-token, got %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"login":"org1"},{"login":"org2"}]`))
+	}))
+	defer server.Close()
+
+	// FetchGitHubOrgs with baseURL uses baseURL + "/api/v3/user/orgs"
+	orgs, err := FetchGitHubOrgs("test-token", server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(orgs) != 2 {
+		t.Fatalf("expected 2 orgs, got %d", len(orgs))
+	}
+	if orgs[0] != "org1" || orgs[1] != "org2" {
+		t.Errorf("expected [org1, org2], got %v", orgs)
+	}
+}
+
+func TestFetchGitHubOrgsDefaultURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"login":"myorg"}]`))
+	}))
+	defer server.Close()
+
+	// Can't easily test the default github.com URL without mocking,
+	// but we can test the baseURL path with our server.
+	orgs, err := FetchGitHubOrgs("token", server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(orgs) != 1 || orgs[0] != "myorg" {
+		t.Errorf("expected [myorg], got %v", orgs)
+	}
+}
+
+func TestFetchGitHubOrgsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	_, err := FetchGitHubOrgs("bad-token", server.URL)
+	if err == nil {
+		t.Error("expected error for non-200 status")
+	}
+}
+
+func TestFetchGitHubOrgsInvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	_, err := FetchGitHubOrgs("token", server.URL)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestCheckUserAllowedByOrg(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"login":"allowed-org"},{"login":"other-org"}]`))
+	}))
+	defer server.Close()
+
+	user := goth.User{NickName: "someuser", AccessToken: "test-token"}
+	cfg := config.OAuthProviderConfig{
+		Provider:    "github",
+		AllowedOrgs: []string{"allowed-org"},
+		BaseURL:     server.URL,
+	}
+
+	allowed, err := CheckUserAllowed(user, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Error("expected user to be allowed by org membership")
+	}
+}
+
+func TestCheckUserDeniedByOrg(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"login":"other-org"}]`))
+	}))
+	defer server.Close()
+
+	user := goth.User{NickName: "someuser", AccessToken: "test-token"}
+	cfg := config.OAuthProviderConfig{
+		Provider:    "github",
+		AllowedOrgs: []string{"required-org"},
+		BaseURL:     server.URL,
+	}
+
+	allowed, err := CheckUserAllowed(user, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Error("expected user to be denied when not in required org")
+	}
+}
+
+func TestCheckUserAllowedOrgFetchError(t *testing.T) {
+	user := goth.User{NickName: "someuser", AccessToken: "test-token"}
+	cfg := config.OAuthProviderConfig{
+		Provider:    "github",
+		AllowedOrgs: []string{"some-org"},
+		BaseURL:     "http://localhost:1", // unreachable
+	}
+
+	_, err := CheckUserAllowed(user, cfg)
+	if err == nil {
+		t.Error("expected error when org fetch fails")
 	}
 }
 


### PR DESCRIPTION
## Summary

Add tests for previously uncovered code paths in `internal/auth/`:

**oauth_test.go** (new tests):
- `TestFetchGitHubOrgs` — success with httptest server
- `TestFetchGitHubOrgsDefaultURL` — baseURL path
- `TestFetchGitHubOrgsAPIError` — non-200 status
- `TestFetchGitHubOrgsInvalidJSON` — malformed response
- `TestCheckUserAllowedByOrg` — allowed via org membership
- `TestCheckUserDeniedByOrg` — denied when not in required org
- `TestCheckUserAllowedOrgFetchError` — unreachable org API

**session_test.go** (new tests):
- `TestCreateSessionOverwritesExisting` — re-login overwrites user
- `TestValidateSessionEmptyUserID` — empty user_id rejected
- `TestNewSessionManagerSecureFlag` — Secure cookie flag
- `TestStoreReturnsUnderlyingStore` — Store() accessor

**middleware_test.go** (new test):
- `TestGetUserIDNoSession` — returns empty string when no session

Fixes #129

## Test plan

- [x] `go test -cover ./internal/auth/...` — 94.7% coverage (was 63.8%)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)