### PR TITLE
Buffer datasource response before writing HTTP headers

### DIFF
--- a/internal/handler/label_values.go
+++ b/internal/handler/label_values.go
@@ -43,9 +43,12 @@ func (h *LabelValuesHandler) Handle(c *gin.Context) {
 	}
 	defer func() { _ = body.Close() }()
 
-	c.Header("Content-Type", "application/json")
-	c.Status(statusCode)
-	if _, err := io.Copy(c.Writer, body); err != nil {
-		slog.Error("failed to stream datasource response", "error", err)
+	data, err := io.ReadAll(body)
+	if err != nil {
+		slog.Error("failed to read datasource response", "error", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read datasource response"})
+		return
 	}
+
+	c.Data(statusCode, "application/json", data)
 }

--- a/internal/handler/query.go
+++ b/internal/handler/query.go
@@ -45,9 +45,12 @@ func (h *QueryHandler) Handle(c *gin.Context) {
 	}
 	defer func() { _ = body.Close() }()
 
-	c.Header("Content-Type", "application/json")
-	c.Status(statusCode)
-	if _, err := io.Copy(c.Writer, body); err != nil {
-		slog.Error("failed to stream datasource response", "error", err)
+	data, err := io.ReadAll(body)
+	if err != nil {
+		slog.Error("failed to read datasource response", "error", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read datasource response"})
+		return
 	}
+
+	c.Data(statusCode, "application/json", data)
 }


### PR DESCRIPTION
## Summary

Fix error handling in `query.go` and `label_values.go` when reading datasource responses.

**Before:** `c.Status(statusCode)` was called before `io.Copy`, flushing HTTP headers. If the stream failed mid-read, the client received a partial response with a 200 status — no way to signal an error.

**After:** The full response body is read with `io.ReadAll` before any headers are sent. If the read fails, a proper 502 JSON error response is returned to the client.

This is safe because Prometheus query responses are bounded JSON payloads, not unbounded streams.

Fixes #125

## Test plan

- [x] `go test ./internal/handler/...` — all passing (existing tests verify correct proxying)
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)