### PR TITLE
Add React Error Boundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,65 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('Uncaught error:', error, info.componentStack);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: '2rem', textAlign: 'center' }}>
+          <h1>Something went wrong</h1>
+          <p style={{ color: '#666', marginBottom: '1rem' }}>
+            An unexpected error occurred. Try reloading the page.
+          </p>
+          <pre
+            style={{
+              textAlign: 'left',
+              background: '#f5f5f5',
+              padding: '1rem',
+              borderRadius: '4px',
+              maxWidth: '600px',
+              margin: '0 auto',
+              overflow: 'auto',
+              fontSize: '0.85rem',
+            }}
+          >
+            {this.state.error?.message}
+          </pre>
+          <button
+            onClick={() => window.location.reload()}
+            style={{
+              marginTop: '1rem',
+              padding: '0.5rem 1rem',
+              cursor: 'pointer',
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import App from './App';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- Add `ErrorBoundary` class component that catches rendering errors and displays a fallback UI with error message and reload button
- Wrap root `<App />` in `main.tsx` with the Error Boundary
- Errors are logged to console via `componentDidCatch`

Fixes #131

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Manually trigger a rendering error to confirm the fallback UI is displayed
- [ ] Confirm error details are logged to the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)