### PR TITLE
Add nur-packages support via GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -44,3 +47,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUR_GITHUB_TOKEN: ${{ secrets.NUR_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,6 +50,17 @@ docker_manifests:
       - "ghcr.io/tokuhirom/dashyard:{{ .Version }}-amd64"
       - "ghcr.io/tokuhirom/dashyard:{{ .Version }}-arm64"
 
+nix:
+  - name: dashyard
+    repository:
+      owner: tokuhirom
+      name: nur-packages
+      token: "{{ .Env.NUR_GITHUB_TOKEN }}"
+    homepage: "https://github.com/tokuhirom/dashyard"
+    description: "Lightweight Prometheus metrics dashboard"
+    license: "mit"
+    path: pkgs/dashyard/default.nix
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Summary
- Add `nix` section to `.goreleaser.yaml` to publish Nix package to `tokuhirom/nur-packages` on release
- Add `Install Nix` step and `NUR_GITHUB_TOKEN` env to release workflow

## Prerequisites
- `NUR_GITHUB_TOKEN` secret must be configured in the repository settings (a PAT with write access to `tokuhirom/nur-packages`)

## Test plan
- [ ] Verify CI passes
- [ ] On next release tag, confirm GoReleaser pushes `pkgs/dashyard/default.nix` to `nur-packages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)