### PR TITLE
Add custom HTTP headers support to datasource configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ datasources:
     url: "http://localhost:9090"
     timeout: 30s
     default: true
-    # headers:                              # Optional custom HTTP headers
-    #   Authorization: "Bearer ${MY_TOKEN}" # Supports ${VAR} env expansion
+    # headers:                                # Optional custom HTTP headers
+    #   - name: Authorization
+    #     value: "Bearer ${MY_TOKEN}"        # Supports ${VAR} env expansion
 
 users:
   - id: "admin"
@@ -242,8 +243,10 @@ datasources:
     url: "https://prometheus.example.com"
     default: true
     headers:
-      Authorization: "Bearer ${PROMETHEUS_TOKEN}"
-      X-Scope-OrgID: "my-tenant"
+      - name: Authorization
+        value: "Bearer ${PROMETHEUS_TOKEN}"
+      - name: X-Scope-OrgID
+        value: "my-tenant"
 ```
 
 Header values support environment variable expansion using `${VAR}` or `$VAR` syntax, so credentials can be kept out of config files.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,14 +40,20 @@ type ServerConfig struct {
 	TrustedProxies []string `yaml:"trusted_proxies,omitempty"`
 }
 
+// HeaderConfig represents a single HTTP header as a name/value pair.
+type HeaderConfig struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
 // DatasourceConfig holds settings for a single named datasource.
 type DatasourceConfig struct {
-	Name    string            `yaml:"name"`
-	Type    string            `yaml:"type"`
-	URL     string            `yaml:"url"`
-	Timeout time.Duration     `yaml:"timeout"`
-	Default bool              `yaml:"default"`
-	Headers map[string]string `yaml:"headers,omitempty"`
+	Name    string         `yaml:"name"`
+	Type    string         `yaml:"type"`
+	URL     string         `yaml:"url"`
+	Timeout time.Duration  `yaml:"timeout"`
+	Default bool           `yaml:"default"`
+	Headers []HeaderConfig `yaml:"headers,omitempty"`
 }
 
 // DashboardsConfig holds dashboard directory settings.
@@ -119,8 +125,8 @@ func Parse(data []byte) (*Config, error) {
 
 	// Expand environment variables in datasource header values
 	for i, ds := range cfg.Datasources {
-		for k, v := range ds.Headers {
-			cfg.Datasources[i].Headers[k] = os.ExpandEnv(v)
+		for j, h := range ds.Headers {
+			cfg.Datasources[i].Headers[j].Value = os.ExpandEnv(h.Value)
 		}
 	}
 

--- a/internal/datasource/registry.go
+++ b/internal/datasource/registry.go
@@ -24,7 +24,11 @@ func NewRegistry(datasources []config.DatasourceConfig) (*Registry, error) {
 		case "prometheus":
 			var opts []prometheus.ClientOption
 			if len(ds.Headers) > 0 {
-				opts = append(opts, prometheus.WithHeaders(ds.Headers))
+				headers := make([]prometheus.Header, len(ds.Headers))
+				for i, h := range ds.Headers {
+					headers[i] = prometheus.Header{Name: h.Name, Value: h.Value}
+				}
+				opts = append(opts, prometheus.WithHeaders(headers))
 			}
 			clients[ds.Name] = prometheus.NewClient(ds.URL, ds.Timeout, opts...)
 		default:

--- a/internal/datasource/registry_test.go
+++ b/internal/datasource/registry_test.go
@@ -97,9 +97,9 @@ func TestNewRegistryWithHeaders(t *testing.T) {
 			URL:     "http://prom:9090",
 			Timeout: 30 * time.Second,
 			Default: true,
-			Headers: map[string]string{
-				"Authorization": "Bearer secret",
-				"X-Scope-OrgID": "tenant-1",
+			Headers: []config.HeaderConfig{
+				{Name: "Authorization", Value: "Bearer secret"},
+				{Name: "X-Scope-OrgID", Value: "tenant-1"},
 			},
 		},
 	}

--- a/internal/prometheus/discovery_test.go
+++ b/internal/prometheus/discovery_test.go
@@ -124,9 +124,9 @@ func TestWithHeadersSent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	headers := map[string]string{
-		"Authorization": "Bearer custom-token",
-		"X-Scope-OrgID": "my-org",
+	headers := []Header{
+		{Name: "Authorization", Value: "Bearer custom-token"},
+		{Name: "X-Scope-OrgID", Value: "my-org"},
 	}
 	client := NewClient(server.URL, 5*time.Second, WithHeaders(headers))
 	_, err := client.MetricNames(context.Background())

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -72,10 +72,22 @@
             "default": false
           },
           "headers": {
-            "type": "object",
-            "description": "Custom HTTP headers to include in every request to this datasource. Values support environment variable expansion using ${VAR} syntax (e.g. Authorization: Bearer ${MY_TOKEN}).",
-            "additionalProperties": {
-              "type": "string"
+            "type": "array",
+            "description": "Custom HTTP headers to include in every request to this datasource. Values support environment variable expansion using ${VAR} syntax.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "HTTP header name (e.g. 'Authorization')."
+                },
+                "value": {
+                  "type": "string",
+                  "description": "HTTP header value. Supports ${VAR} environment variable expansion (e.g. 'Bearer ${MY_TOKEN}')."
+                }
+              },
+              "required": ["name", "value"],
+              "additionalProperties": false
             }
           }
         },


### PR DESCRIPTION
## Summary
- Add `headers` field to datasource config for custom HTTP headers per datasource
- Header values support environment variable expansion using `${VAR}` syntax, enabling credential separation from config files
- Refactor Prometheus client to use a generic headers map instead of bearer-token-only field, with backward-compatible `WithBearerToken` option

## Config example
```yaml
datasources:
  - name: prod
    type: prometheus
    url: "https://prometheus.example.com"
    default: true
    headers:
      Authorization: "Bearer ${MY_GREAT_TOKEN}"
      X-Scope-OrgID: "my-tenant"
```

## Changed files
- `internal/config/config.go` — Add `Headers` field, env var expansion via `os.ExpandEnv`
- `internal/prometheus/client.go` — Replace `bearerToken` with generic `headers` map, add `WithHeaders` option
- `internal/datasource/registry.go` — Pass headers to Prometheus client
- `schemas/config.schema.json` — Add `headers` property to datasource schema
- Tests for config parsing, env expansion, client headers, and registry

## Test plan
- [x] `go test ./internal/config/...` — headers parsing, env expansion, unset vars
- [x] `go test ./internal/prometheus/...` — WithHeaders sends headers, WithBearerToken still works
- [x] `go test ./internal/datasource/...` — registry creates client with headers
- [x] `golangci-lint run` — no issues