### PR TITLE
Limit chart legend maxHeight to prevent graph area shrinking

### DIFF
--- a/frontend/src/components/GraphPanel.tsx
+++ b/frontend/src/components/GraphPanel.tsx
@@ -162,6 +162,7 @@ export function GraphPanel({ title, data, unit, yMin, yMax, legend, thresholds, 
     plugins: {
       legend: {
         position: 'bottom' as const,
+        maxHeight: 60,
         labels: {
           boxWidth: 12,
           usePointStyle: true,


### PR DESCRIPTION
## Summary

- Add `maxHeight: 60` to Chart.js legend plugin config in `GraphPanel.tsx`
- When a panel has many series (3+), the bottom legend grows and squeezes the chart drawing area
- With `maxHeight` set, the legend is capped at ~2-3 rows (60px), keeping the graph readable

## Test plan

- [x] `npm run build` passes (type-check + Vite build)
- [ ] Visually verify with a dashboard that has panels with many series