### PR TITLE
Clear invalid session cookie on auth failure

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -14,6 +14,8 @@ func AuthMiddleware(sm *SessionManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, err := sm.ValidateSession(c.Request)
 		if err != nil {
+			// Clear the invalid/corrupt session cookie so re-login works cleanly
+			sm.ExpireCookie(c.Writer)
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"error": "unauthorized",
 			})

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -112,4 +112,52 @@ func TestAuthMiddlewareInvalidCookie(t *testing.T) {
 	if resp.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401, got %d", resp.Code)
 	}
+
+	// Verify the invalid cookie is cleared in the response
+	cleared := false
+	for _, c := range resp.Result().Cookies() {
+		if c.Name == "dashyard_session" && c.MaxAge < 0 {
+			cleared = true
+			break
+		}
+	}
+	if !cleared {
+		t.Error("expected invalid session cookie to be cleared in response")
+	}
+}
+
+func TestAuthMiddlewareWrongSecret(t *testing.T) {
+	sm1 := NewSessionManager("secret-for-instance-aaaaaaaa!!", false)
+	sm2 := NewSessionManager("secret-for-instance-bbbbbbbb!!", false)
+
+	// Create a session with instance 1
+	cookie := createTestSessionCookie(sm1, "admin")
+
+	// Try to use it with instance 2
+	router := gin.New()
+	router.Use(AuthMiddleware(sm2))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.AddCookie(cookie)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.Code)
+	}
+
+	// Verify the cookie from the other instance is cleared
+	cleared := false
+	for _, c := range resp.Result().Cookies() {
+		if c.Name == "dashyard_session" && c.MaxAge < 0 {
+			cleared = true
+			break
+		}
+	}
+	if !cleared {
+		t.Error("expected session cookie from different instance to be cleared")
+	}
 }

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -71,6 +71,21 @@ func (sm *SessionManager) ClearSession(r *http.Request, w http.ResponseWriter) e
 	return session.Save(r, w)
 }
 
+// ExpireCookie writes a Set-Cookie header that expires the session cookie.
+// Unlike ClearSession, this works even when the existing cookie is corrupt
+// or was created by a different instance with a different secret.
+func (sm *SessionManager) ExpireCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   sm.store.Options.Secure,
+	})
+}
+
 // Store returns the underlying CookieStore (used by gothic).
 func (sm *SessionManager) Store() *sessions.CookieStore {
 	return sm.store


### PR DESCRIPTION
## Summary
- When the auth middleware encounters an invalid or corrupt session cookie, it now expires the cookie in the response via `Set-Cookie` header
- This fixes the issue where running a different dashyard instance on the same origin causes persistent "invalid credentials" errors because the old cookie (encrypted with a different secret) can't be decoded
- Added `ExpireCookie()` method to `SessionManager` that writes an expiry cookie directly, bypassing `gorilla/sessions` decode (which fails on corrupt cookies)

## Test plan
- [x] `go test ./internal/auth/...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [ ] Start instance A, log in, stop it. Start instance B on the same port with a different secret. Verify the login page appears and re-login works without clearing cookies manually.