### PR TITLE
Replace --bearer-token with --header in gen-prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The `gen-prompt` command reads metrics from your Prometheus server and produces 
 
 ```bash
 ./dashyard gen-prompt http://localhost:9090 -o .
-./dashyard gen-prompt https://prom.example.com --bearer-token "eyJ..."
+./dashyard gen-prompt https://prom.example.com -H "Authorization: Bearer eyJ..."
 ./dashyard gen-prompt http://localhost:9090 --match "node_.*" -o .
 ```
 

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -20,14 +20,6 @@ type Header struct {
 	Value string
 }
 
-// WithBearerToken sets a bearer token for authentication.
-// This is a convenience wrapper that adds an Authorization header.
-func WithBearerToken(token string) ClientOption {
-	return func(c *Client) {
-		c.headers = append(c.headers, Header{Name: "Authorization", Value: "Bearer " + token})
-	}
-}
-
 // WithHeaders sets custom HTTP headers to include in every request.
 func WithHeaders(headers []Header) ClientOption {
 	return func(c *Client) {

--- a/internal/prometheus/discovery_test.go
+++ b/internal/prometheus/discovery_test.go
@@ -95,26 +95,6 @@ func TestMetricLabels(t *testing.T) {
 	}
 }
 
-func TestBearerTokenSent(t *testing.T) {
-	var receivedAuth string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedAuth = r.Header.Get("Authorization")
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"status":"success","data":["up"]}`))
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, 5*time.Second, WithBearerToken("test-token-123"))
-	_, err := client.MetricNames(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	expected := "Bearer test-token-123"
-	if receivedAuth != expected {
-		t.Errorf("expected Authorization %q, got %q", expected, receivedAuth)
-	}
-}
-
 func TestWithHeadersSent(t *testing.T) {
 	var receivedHeaders http.Header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -141,7 +121,7 @@ func TestWithHeadersSent(t *testing.T) {
 	}
 }
 
-func TestBearerTokenNotSentWhenEmpty(t *testing.T) {
+func TestNoHeadersSentByDefault(t *testing.T) {
 	var receivedAuth string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuth = r.Header.Get("Authorization")


### PR DESCRIPTION
## Summary
- Remove `--bearer-token` flag from `gen-prompt` command
- Add `-H`/`--header` flag accepting `Name: Value` format (repeatable)
- Remove unused `WithBearerToken` convenience function from prometheus client
- Update README example

### Before
```bash
./dashyard gen-prompt https://prom.example.com --bearer-token "eyJ..."
```

### After
```bash
./dashyard gen-prompt https://prom.example.com -H "Authorization: Bearer eyJ..."
./dashyard gen-prompt https://prom.example.com -H "Authorization: Bearer eyJ..." -H "X-Scope-OrgID: my-org"
```

This aligns with the datasource config's `headers` field and supports arbitrary headers (e.g. `X-Scope-OrgID` for Cortex/Mimir).

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)