### PR TITLE
Show repeat variables as disabled in selector, add hide option

### DIFF
--- a/frontend/src/components/DashboardView.tsx
+++ b/frontend/src/components/DashboardView.tsx
@@ -24,14 +24,20 @@ export function DashboardView({ path, timeRange, onAuthError, columns, variableV
     setVariableValue(name, value);
     onVariableValuesChange({ ...variableValues, [name]: value });
   }, [setVariableValue, onVariableValuesChange, variableValues]);
-  // Hide variables that are only used for row repeat (selecting them has no effect)
   const repeatVarNames = useMemo(() => {
     if (!dashboard) return new Set<string>();
     return new Set(dashboard.rows.map((r) => r.repeat).filter(Boolean) as string[]);
   }, [dashboard]);
+
+  // Only hide variables with explicit hide: true
+  const hiddenVarNames = useMemo(() => {
+    if (!dashboard?.variables) return new Set<string>();
+    return new Set(dashboard.variables.filter((v) => v.hide).map((v) => v.name));
+  }, [dashboard]);
+
   const visibleVariables = useMemo(
-    () => variables.filter((v) => !repeatVarNames.has(v.name)),
-    [variables, repeatVarNames],
+    () => variables.filter((v) => !hiddenVarNames.has(v.name)),
+    [variables, hiddenVarNames],
   );
   const [showSource, setShowSource] = useState(false);
   const [source, setSource] = useState<string | null>(null);
@@ -88,7 +94,7 @@ export function DashboardView({ path, timeRange, onAuthError, columns, variableV
       ) : (
         <>
           {visibleVariables.length > 0 && (
-            <VariableBar variables={visibleVariables} onValueChange={handleVariableChange} />
+            <VariableBar variables={visibleVariables} repeatVarNames={repeatVarNames} onValueChange={handleVariableChange} />
           )}
           {varsLoading ? (
             <div className="dashboard-loading">Loading variables...</div>

--- a/frontend/src/components/VariableBar.tsx
+++ b/frontend/src/components/VariableBar.tsx
@@ -2,36 +2,48 @@ import type { VariableState } from '../hooks/useVariables';
 
 interface VariableBarProps {
   variables: VariableState[];
+  repeatVarNames: Set<string>;
   onValueChange: (name: string, value: string) => void;
 }
 
-export function VariableBar({ variables, onValueChange }: VariableBarProps) {
+export function VariableBar({ variables, repeatVarNames, onValueChange }: VariableBarProps) {
   if (variables.length === 0) return null;
 
   return (
     <div className="variable-bar">
-      {variables.map((variable) => (
-        <div key={variable.name} className="variable-selector">
-          <label className="variable-label">{variable.label}</label>
-          {variable.loading ? (
-            <span className="variable-loading">Loading...</span>
-          ) : variable.error ? (
-            <span className="variable-error">{variable.error}</span>
-          ) : (
-            <select
-              className="variable-select"
-              value={variable.selected}
-              onChange={(e) => onValueChange(variable.name, e.target.value)}
-            >
-              {variable.values.map((value) => (
-                <option key={value} value={value}>
-                  {value}
-                </option>
-              ))}
-            </select>
-          )}
-        </div>
-      ))}
+      {variables.map((variable) => {
+        const isRepeat = repeatVarNames.has(variable.name);
+        return (
+          <div key={variable.name} className="variable-selector">
+            <label className="variable-label">
+              {variable.label}
+              {isRepeat && <span className="variable-repeat-badge">row repeat</span>}
+            </label>
+            {variable.loading ? (
+              <span className="variable-loading">Loading...</span>
+            ) : variable.error ? (
+              <span className="variable-error">{variable.error}</span>
+            ) : (
+              <select
+                className="variable-select"
+                value={variable.selected}
+                onChange={(e) => onValueChange(variable.name, e.target.value)}
+                disabled={isRepeat}
+              >
+                {isRepeat ? (
+                  <option value={variable.selected}>All ({variable.values.length})</option>
+                ) : (
+                  variable.values.map((value) => (
+                    <option key={value} value={value}>
+                      {value}
+                    </option>
+                  ))
+                )}
+              </select>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -304,6 +304,21 @@ body {
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
+.variable-select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.variable-repeat-badge {
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--color-primary);
+  background: rgba(59, 130, 246, 0.1);
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-left: 4px;
+}
+
 .variable-loading,
 .variable-error {
   font-size: 12px;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -33,6 +33,7 @@ export interface Variable {
   label?: string;
   query?: string;
   datasource?: string;
+  hide?: boolean;
 }
 
 export interface DatasourcesResponse {

--- a/internal/model/dashboard.go
+++ b/internal/model/dashboard.go
@@ -42,6 +42,7 @@ type Variable struct {
 	Label      string `yaml:"label,omitempty" json:"label,omitempty"`
 	Query      string `yaml:"query,omitempty" json:"query,omitempty"`
 	Datasource string `yaml:"datasource,omitempty" json:"datasource,omitempty"`
+	Hide       bool   `yaml:"hide,omitempty" json:"hide,omitempty"`
 }
 
 // Dashboard represents a single dashboard definition loaded from YAML.

--- a/internal/prompt/format_reference.md
+++ b/internal/prompt/format_reference.md
@@ -6,6 +6,7 @@ variables:                          # optional
   - name: device                    # variable name used as $device in queries
     label: "Network Device"         # display label
     query: "label_values(metric_name, label_name)"
+    hide: false                     # when true, hide from selector bar
 rows:
   - title: "Row Title"
     repeat: device                  # optional: repeat row for each variable value

--- a/schemas/dashboard.schema.json
+++ b/schemas/dashboard.schema.json
@@ -52,6 +52,11 @@
         "datasource": {
           "type": "string",
           "description": "Name of the datasource to query. Uses the default datasource when omitted. Forbidden for type 'datasource'."
+        },
+        "hide": {
+          "type": "boolean",
+          "description": "When true, hide this variable from the selector bar. The variable still works in queries and repeat rows.",
+          "default": false
         }
       },
       "required": ["name"],


### PR DESCRIPTION
## Summary
- **Repeat variables are now visible** in the variable selector bar instead of being silently hidden. They appear as disabled dropdowns with a "row repeat" badge and "All (N)" text showing how many values exist
- **New `hide` field** on variables (`hide: true`) allows dashboard authors to explicitly hide a variable from the selector bar. The variable still works in queries and repeat rows
- Updated Go model, TypeScript types, JSON schema, and format reference

### Before
Variables used in `repeat` rows simply disappeared from the selector bar with no explanation.

### After
Repeat variables show as disabled with a clear "row repeat" badge. Authors can also use `hide: true` to intentionally hide any variable.

## Test plan
- [x] `cd frontend && npm run build` — type check + build passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Verify in kitchensink: repeat variables show as disabled with "row repeat" badge
- [ ] Verify `hide: true` hides a variable from the selector bar