### PR TITLE
Add pipe functions to legend templates

### DIFF
--- a/frontend/src/components/GraphPanel.tsx
+++ b/frontend/src/components/GraphPanel.tsx
@@ -19,6 +19,7 @@ import annotationPlugin from 'chartjs-plugin-annotation';
 import 'chartjs-adapter-date-fns';
 import type { QueryResponse, Threshold } from '../types';
 import { getYAxisTickCallback } from '../utils/units';
+import { buildLabel } from '../utils/legend';
 
 ChartJS.register(
   CategoryScale,
@@ -86,16 +87,6 @@ const COLORS = [
   '#ec4899', '#06b6d4', '#84cc16', '#f97316', '#6366f1',
 ];
 
-function buildLabel(metric: Record<string, string>, legend?: string): string {
-  if (legend) {
-    return legend.replace(/\{([^}]+)\}/g, (_, key) => metric[key] ?? '');
-  }
-  const entries = Object.entries(metric).filter(([k]) => k !== '__name__');
-  if (entries.length === 0) {
-    return metric['__name__'] || 'value';
-  }
-  return entries.map(([k, v]) => `${k}="${v}"`).join(', ');
-}
 
 export function GraphPanel({ title, data, unit, yMin, yMax, legend, thresholds, chartType, stacked, yScale, loading, error, id }: GraphPanelProps) {
   const [expanded, setExpanded] = useState(false);

--- a/frontend/src/utils/legend.test.ts
+++ b/frontend/src/utils/legend.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { buildLabel } from './legend';
+
+describe('buildLabel', () => {
+  const metric = {
+    __name__: 'http_requests_total',
+    method: 'GET',
+    status: '200',
+    instance_id: '550e8400-e29b-41d4-a716-446655440000',
+    request_id: '0192d2a4-b6c0-7a3a-8e1f-4a5b6c7d8e9f',
+  };
+
+  describe('basic interpolation', () => {
+    it('replaces label name with value', () => {
+      expect(buildLabel(metric, '{method}')).toBe('GET');
+    });
+
+    it('replaces multiple labels', () => {
+      expect(buildLabel(metric, '{method} {status}')).toBe('GET 200');
+    });
+
+    it('returns empty string for missing label', () => {
+      expect(buildLabel(metric, '{nonexistent}')).toBe('');
+    });
+
+    it('falls back to all labels when no legend', () => {
+      const m = { __name__: 'up', job: 'api', instance: 'localhost' };
+      expect(buildLabel(m)).toBe('job="api", instance="localhost"');
+    });
+
+    it('uses __name__ when no other labels', () => {
+      expect(buildLabel({ __name__: 'up' })).toBe('up');
+    });
+
+    it('returns "value" when no labels at all', () => {
+      expect(buildLabel({})).toBe('value');
+    });
+  });
+
+  describe('trunc', () => {
+    it('truncates to N chars with ...', () => {
+      expect(buildLabel(metric, '{instance_id | trunc(8)}')).toBe('550e8400...');
+    });
+
+    it('does not truncate when value is shorter than N', () => {
+      expect(buildLabel(metric, '{method | trunc(10)}')).toBe('GET');
+    });
+
+    it('does not truncate when value equals N', () => {
+      expect(buildLabel(metric, '{method | trunc(3)}')).toBe('GET');
+    });
+  });
+
+  describe('suffix', () => {
+    it('shows last N chars with ...', () => {
+      expect(buildLabel(metric, '{instance_id | suffix(8)}')).toBe('...55440000');
+    });
+
+    it('does not truncate when value is shorter than N', () => {
+      expect(buildLabel(metric, '{method | suffix(10)}')).toBe('GET');
+    });
+  });
+
+  describe('upper / lower', () => {
+    it('converts to uppercase', () => {
+      expect(buildLabel(metric, '{method | upper}')).toBe('GET');
+    });
+
+    it('converts to lowercase', () => {
+      expect(buildLabel(metric, '{method | lower}')).toBe('get');
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces substring', () => {
+      expect(buildLabel(metric, '{method | replace("GET","POST")}')).toBe('POST');
+    });
+
+    it('replaces all occurrences', () => {
+      const m = { val: 'a-b-c' };
+      expect(buildLabel(m, '{val | replace("-","_")}')).toBe('a_b_c');
+    });
+
+    it('returns value unchanged on invalid args', () => {
+      expect(buildLabel(metric, '{method | replace(bad)}')).toBe('GET');
+    });
+  });
+
+  describe('pipe chaining', () => {
+    it('applies multiple functions in order', () => {
+      expect(buildLabel(metric, '{instance_id | trunc(8) | upper}')).toBe('550E8400...');
+    });
+
+    it('chains suffix and upper', () => {
+      expect(buildLabel(metric, '{method | lower | replace("get","post")}')).toBe('post');
+    });
+  });
+
+  describe('mixed template', () => {
+    it('handles pipes in some placeholders and plain in others', () => {
+      expect(buildLabel(metric, '{method} {instance_id | trunc(8)}')).toBe('GET 550e8400...');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles unknown function gracefully', () => {
+      expect(buildLabel(metric, '{method | nonexistent(5)}')).toBe('GET');
+    });
+
+    it('handles empty pipe expression', () => {
+      expect(buildLabel(metric, '{method |}')).toBe('GET');
+    });
+
+    it('handles trunc(0)', () => {
+      expect(buildLabel(metric, '{method | trunc(0)}')).toBe('GET');
+    });
+
+    it('handles negative trunc', () => {
+      expect(buildLabel(metric, '{method | trunc(-1)}')).toBe('GET');
+    });
+  });
+});

--- a/frontend/src/utils/legend.ts
+++ b/frontend/src/utils/legend.ts
@@ -1,0 +1,67 @@
+type LegendFunc = (value: string, arg: string) => string;
+
+const legendFuncs: Record<string, LegendFunc> = {
+  trunc(value, arg) {
+    const n = parseInt(arg, 10);
+    if (isNaN(n) || n <= 0 || value.length <= n) return value;
+    return value.slice(0, n) + '...';
+  },
+  suffix(value, arg) {
+    const n = parseInt(arg, 10);
+    if (isNaN(n) || n <= 0 || value.length <= n) return value;
+    return '...' + value.slice(-n);
+  },
+  upper(value) {
+    return value.toUpperCase();
+  },
+  lower(value) {
+    return value.toLowerCase();
+  },
+  replace(value, arg) {
+    // replace("old","new")
+    const m = arg.match(/^"([^"]*)"\s*,\s*"([^"]*)"$/);
+    if (!m) return value;
+    return value.split(m[1]).join(m[2]);
+  },
+};
+
+// Parse "funcName(arg)" or "funcName" and return [funcName, arg], or null.
+function parseFuncCall(expr: string): [string, string] | null {
+  const m = expr.match(/^(\w+)\(([^)]*)\)$/);
+  if (m) return [m[1], m[2]];
+  // No-arg form: "funcName"
+  const m2 = expr.match(/^(\w+)$/);
+  if (m2 && legendFuncs[m2[1]]) return [m2[1], ''];
+  return null;
+}
+
+function applyPipe(value: string, pipeExpr: string): string {
+  const parts = pipeExpr.split('|');
+  let result = value;
+  for (let i = 1; i < parts.length; i++) {
+    const parsed = parseFuncCall(parts[i].trim());
+    if (!parsed) continue;
+    const [funcName, arg] = parsed;
+    const fn = legendFuncs[funcName];
+    if (fn) {
+      result = fn(result, arg);
+    }
+  }
+  return result;
+}
+
+export function buildLabel(metric: Record<string, string>, legend?: string): string {
+  if (legend) {
+    return legend.replace(/\{([^}]+)\}/g, (_, expr: string) => {
+      const labelName = expr.split('|')[0].trim();
+      const value = metric[labelName] ?? '';
+      if (!expr.includes('|')) return value;
+      return applyPipe(value, expr);
+    });
+  }
+  const entries = Object.entries(metric).filter(([k]) => k !== '__name__');
+  if (entries.length === 0) {
+    return metric['__name__'] || 'value';
+  }
+  return entries.map(([k, v]) => `${k}="${v}"`).join(', ');
+}

--- a/internal/prompt/format_reference.md
+++ b/internal/prompt/format_reference.md
@@ -73,6 +73,28 @@ rate(hits_total[5m]) / (rate(hits_total[5m]) + rate(misses_total[5m]) > 0) * 100
 
 The `> 0` filter drops zero-denominator samples so the panel shows no data instead of `NaN`.
 
+## Legend Template Functions
+
+Legend templates support pipe-style functions for transforming label values:
+
+```yaml
+legend: "{instance_id | trunc(8)}"          # first 8 chars + "..."
+legend: "{request_id | suffix(8)}"          # "..." + last 8 chars
+legend: "{method | upper}"                  # uppercase
+legend: "{path | lower}"                    # lowercase
+legend: "{fqdn | replace(\".example.com\",\"\")}"  # remove substring
+legend: "{id | trunc(8) | upper}"           # chain multiple functions
+```
+
+Available functions:
+- `trunc(n)` — keep first N characters, append "..." if truncated
+- `suffix(n)` — keep last N characters, prepend "..." if truncated
+- `upper` — convert to uppercase
+- `lower` — convert to lowercase
+- `replace("old","new")` — replace all occurrences of a substring
+
+Use `trunc` for UUIDv4 labels (prefix is distinctive) and `suffix` for UUIDv7 labels (timestamp suffix is distinctive).
+
 ## Stacked Charts
 
 Use `stacked: true` when series represent parts of a whole that sum to a meaningful total (e.g. memory by state: used + cached + free + buffers = total). Do not stack independent series that overlap (e.g. CPU utilization per core).


### PR DESCRIPTION
## Summary
- Legend templates now support Jinja2/Loki-style pipe functions for transforming label values
- Useful for shortening UUIDs and other long labels in graph legends
- Extract `buildLabel` from `GraphPanel.tsx` into `utils/legend.ts` for testability

### Syntax
```yaml
legend: "{instance_id | trunc(8)}"              # 550e8400...
legend: "{request_id | suffix(8)}"              # ...4a5b6c7d
legend: "{method | upper}"                      # GET
legend: "{path | lower}"                        # /api/users
legend: "{fqdn | replace(\".example.com\",\"\")}"  # host1
legend: "{id | trunc(8) | upper}"               # chaining
```

### Available functions
| Function | Description |
|----------|-------------|
| `trunc(n)` | Keep first N chars, append "..." if truncated |
| `suffix(n)` | Keep last N chars, prepend "..." if truncated |
| `upper` | Uppercase |
| `lower` | Lowercase |
| `replace("old","new")` | Replace all occurrences |

## Test plan
- [x] `cd frontend && npm run build` — type check + build passes
- [x] `npx vitest run` — 74 tests pass (23 new legend tests)
- [ ] Verify in kitchensink with a legend like `{method | lower}`