### PR TITLE
Add --log-level CLI option and Prometheus request debug logging

### DIFF
--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
@@ -70,6 +71,8 @@ func (c *Client) QueryRange(ctx context.Context, query, start, end, step string)
 	params.Set("step", step)
 	u.RawQuery = params.Encode()
 
+	slog.Debug("prometheus query_range request", "url", u.String())
+
 	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("creating request: %w", err)
@@ -101,6 +104,8 @@ func (c *Client) Ping(ctx context.Context) error {
 		return fmt.Errorf("parsing base URL: %w", err)
 	}
 	u = u.JoinPath("-/ready")
+
+	slog.Debug("prometheus ping request", "url", u.String())
 
 	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
@@ -134,6 +139,8 @@ func (c *Client) LabelValues(ctx context.Context, label, match string) (io.ReadC
 		params.Set("match[]", match)
 		u.RawQuery = params.Encode()
 	}
+
+	slog.Debug("prometheus label values request", "url", u.String())
 
 	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add a global `--log-level` CLI flag (`debug`, `info`, `warn`, `error`, default: `info`) to control slog output level
- Add `slog.Debug` calls to Prometheus client methods (`QueryRange`, `Ping`, `LabelValues`) to log request URLs for debugging
- Uses Kong's `enum` tag for input validation at parse time

## Test plan

- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `go test ./...` passes (existing `server_test.go` failure is pre-existing)
- [ ] Manual: `dashyard serve --log-level debug` shows DEBUG log output
- [ ] Manual: `dashyard serve --log-level info` hides DEBUG log output
- [ ] Manual: `dashyard serve --log-level invalid` shows Kong parse error