### PR TITLE
Remove unnecessary needs dependencies from CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
   backend:
     name: Backend
     runs-on: ubuntu-latest
-    needs: [frontend, lint]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -69,7 +68,6 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [frontend, backend]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -117,7 +115,6 @@ jobs:
   docker:
     name: Docker build
     runs-on: ubuntu-latest
-    needs: [frontend, backend]
     steps:
       - uses: actions/checkout@v6
       - run: docker build -t dashyard .


### PR DESCRIPTION
## Summary
- Remove `needs` from `backend`, `e2e`, and `docker` jobs in CI workflow
- All jobs rebuild everything from scratch (frontend build, Go compile) without using artifacts from prior jobs, so the `needs` declarations only served as failure gates
- This was delaying the start of the heaviest job (E2E tests) until `frontend` → `backend` completed sequentially
- All 5 jobs now start in parallel immediately, reducing overall CI wall-clock time

## Test plan
- [x] Verify all CI jobs pass on this PR
- [x] Confirm E2E job starts immediately without waiting for other jobs