### PR TITLE
Cap default panel span to 6 for panels without explicit span

### DIFF
--- a/frontend/src/components/RowView.tsx
+++ b/frontend/src/components/RowView.tsx
@@ -17,11 +17,11 @@ export function RowView({ row, rowIndex, timeRange, variableValues }: RowViewPro
   const title = substituteVariables(row.title, vars);
 
   // Calculate default span for panels without explicit span.
-  // Uses remaining grid space after explicit spans, with minimum 3 (max 4 panels per row).
+  // Uses remaining grid space after explicit spans, clamped to 3–6.
   const explicitTotal = row.panels.reduce((sum, p) => sum + (p.span || 0), 0);
   const nonExplicitCount = row.panels.filter(p => !p.span).length;
   const defaultSpan = nonExplicitCount > 0
-    ? Math.max(3, Math.floor((12 - explicitTotal) / nonExplicitCount))
+    ? Math.min(6, Math.max(3, Math.floor((12 - explicitTotal) / nonExplicitCount)))
     : 0;
 
   return (


### PR DESCRIPTION
## Summary
- Cap the auto-calculated default span at 6 (half-width) for panels without an explicit `span` value
- Previously, a single panel in a row without `span` would get `span=12` (full width), which was excessively wide
- The default span is now clamped to the range 3–6: `Math.min(6, Math.max(3, ...))`

Fixes #175

## Test plan
- [x] Frontend build passes (`npm run build`)
- [x] Frontend unit tests pass (`npm run test`)
- [x] E2E tests pass (`make test-e2e` — 31 passed)