### PR TITLE
Add --version flag to CLI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{.Version}}
 
 archives:
   - formats:

--- a/main.go
+++ b/main.go
@@ -24,8 +24,11 @@ import (
 //go:embed frontend/dist/*
 var frontendFiles embed.FS
 
+var version = "dev"
+
 var cli struct {
-	LogLevel string `help:"Log level (debug, info, warn, error)." default:"info" enum:"debug,info,warn,error"`
+	LogLevel string           `help:"Log level (debug, info, warn, error)." default:"info" enum:"debug,info,warn,error"`
+	Version  kong.VersionFlag `name:"version" help:"Show version."`
 
 	Serve      ServeCmd      `cmd:"" help:"Start the dashboard server."`
 	Validate   ValidateCmd   `cmd:"" help:"Validate config or dashboard files."`
@@ -165,6 +168,7 @@ func main() {
 	kctx := kong.Parse(&cli,
 		kong.Name("dashyard"),
 		kong.Description("Lightweight Prometheus metrics dashboard."),
+		kong.Vars{"version": version},
 	)
 
 	var level slog.Level


### PR DESCRIPTION
## Summary
- Add `--version` flag using Kong's `VersionFlag` type
- Version defaults to `"dev"` for local builds
- goreleaser injects the actual version via `-X main.version={{.Version}}` ldflags at release time

```
$ dashyard --version
dev

$ go build -ldflags "-X main.version=1.2.3" -o dashyard . && ./dashyard --version
1.2.3
```

## Test plan
- [x] `dashyard --version` prints `dev`
- [x] Version injection via ldflags works
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `go test ./...` passes (except pre-existing `/ready` test failure)