### PR TITLE
Warn when session_secret is not configured

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -126,6 +127,7 @@ func Parse(data []byte) (*Config, error) {
 	}
 
 	if cfg.Server.SessionSecret == "" {
+		slog.Warn("server.session_secret is not set; generating a random secret. Sessions will not persist across server restarts.")
 		secret := make([]byte, 32)
 		if _, err := rand.Read(secret); err != nil {
 			return nil, fmt.Errorf("generating session secret: %w", err)


### PR DESCRIPTION
## Summary
- Log a warning when `server.session_secret` is not set in `config.yaml`
- Without a fixed secret, sessions are lost on every server restart because a new random secret is generated each time

## Test plan
- [ ] Run `go test ./internal/config/...` — passes
- [ ] Start server without `session_secret` in config and verify warning appears in logs
- [ ] Start server with `session_secret` set and verify no warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)